### PR TITLE
Fix #87 | Add type to button to prevent it triggering submit

### DIFF
--- a/src/components/ListeningChallenge.svelte
+++ b/src/components/ListeningChallenge.svelte
@@ -92,7 +92,8 @@
 
       <button
         class="button is-large is-primary"
-        on:click="{playChallengeVoice}">
+        on:click="{playChallengeVoice}"
+        type="button">
         <span class="icon is-medium">
           <i class="fas fa-volume-up "></i>
         </span>


### PR DESCRIPTION
Buttons that doesn't have type in a form will be a submit button by default.