### PR TITLE
Improve 'undefined check' in Cypress tests

### DIFF
--- a/cypress/integration/cards.js
+++ b/cypress/integration/cards.js
@@ -9,6 +9,10 @@ describe("Cards ", () => {
             cy.contains(/Which of these is/).should("be.visible")
         })
 
+        it("undefined not seen on the page", () => {
+            cy.contains(/undefined/).should("not.exist")
+        })
+
         it("Has 3 cards", () => {
             cy.get(".options")
                 .find(".card:visible")

--- a/cypress/integration/optionSelection.js
+++ b/cypress/integration/optionSelection.js
@@ -15,6 +15,10 @@ describe("OptionSelection", () => {
                 .should("have.length", 3)
         })
 
+        it("undefined not seen on the page", () => {
+            cy.contains(/undefined/).should("not.exist")
+        })
+
         it("All options inactive", () => {
             cy.get(".options")
                 .find(".option[data-test=neutral]:visible")

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -20,7 +20,3 @@ import "./commands"
 // require('./commands')
 
 import "@cypress/code-coverage/support"
-
-afterEach(() => {
-    cy.contains(/undefined/).should("not.exist")
-})


### PR DESCRIPTION
this is required because apparently the original solution made
Cypress a bit flaky