### PR TITLE
Fixes #247: autocapitalize issue on iOS 

### DIFF
--- a/src/components/InputFieldWithVirtualKeyboard.svelte
+++ b/src/components/InputFieldWithVirtualKeyboard.svelte
@@ -61,6 +61,7 @@
   placeholder="Type your answer…"
   {disabled}
   spellcheck="false"
+  autocapitalize="none"
   lang="{languageCode}"
   use:focusMe
   bind:value


### PR DESCRIPTION
Adds the `autocapitalize="none"` attribute to the input field.

Commit tested on iOS 13.3