### PR TITLE
fix: fix enter key in ChipsChallenge

### DIFF
--- a/workspaces/web/src/components/ChipsChallenge.svelte
+++ b/workspaces/web/src/components/ChipsChallenge.svelte
@@ -1,5 +1,7 @@
 <script>
+  import { onMount } from "svelte"
   import Sortable from "sortablejs"
+  import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"
   import { writable, get } from "svelte/store"
   import ChallengePanel from "./ChallengePanel"
@@ -94,6 +96,17 @@
     submitted = false
     resolveChallenge()
   }
+
+  onMount(() => {
+    hotkeys.unbind("enter")
+    hotkeys("enter", () => {
+      if (submitted) {
+        finishChallenge()
+      } else {
+        submitChallenge()
+      }
+    })
+  })
 </script>
 
 <form on:submit|preventDefault="{submitChallenge}">


### PR DESCRIPTION
This should fix https://github.com/kantord/LibreLingo/issues/341

It basically adds the same section for binding the enter key as in other files, like `ShortInputChallenge.svelte`. Both continuing and submitting now work for me (Firefox 79.0, Arch Linux).

Sorry if I've oversaw something and `onMount` is not called there for a reason. Also sorry if I violated some code guidelines - svelte is new to me. Making a pull request on github as well, but this project looks pretty cool, so I thought I should contribute somehow :)