### PR TITLE
fix(button): fix lowercase typography on the virtual keyboard

### DIFF
--- a/workspaces/lluis/Button.svelte
+++ b/workspaces/lluis/Button.svelte
@@ -84,6 +84,8 @@
 
   .key {
     font-family: monospace;
+    border-radius: 8px;
+    text-transform: none;
     margin: 1em;
     margin-left: 0;
     margin-top: 0;

--- a/workspaces/web/src/components/InputFieldWithVirtualKeyboard.svelte
+++ b/workspaces/web/src/components/InputFieldWithVirtualKeyboard.svelte
@@ -72,6 +72,7 @@
 <div class="keyboard">
   {#each specialCharacters as specialCharacter}
     <Button
+      class="virtual-key"
       tabindex="-1"
       light
       key


### PR DESCRIPTION
Lowercase typography was broken, because an all-caps font was forced. This doesn't work well for the
virtual keyboard, hence I fixed it

fixes #579