### PR TITLE
feat: add meta descriptions

### DIFF
--- a/workspaces/web/src/components/MarkDownPage.svelte
+++ b/workspaces/web/src/components/MarkDownPage.svelte
@@ -20,10 +20,12 @@
 
   export let readmeHTML
   export let title
+  export let description
 </script>
 
 <svelte:head>
   <title>{title}</title>
+  <meta name="description" content="{description}"/>
 </svelte:head>
 
 <NavBar dark />

--- a/workspaces/web/src/routes/about.svelte
+++ b/workspaces/web/src/routes/about.svelte
@@ -1,5 +1,6 @@
 <script context="module">
   import MarkDownPage, { getMarkDownData } from "../components/MarkDownPage"
+  import { _ } from "svelte-i18n"
 
   export async function preload(page, session) {
     return {
@@ -14,4 +15,4 @@
   export let readmeHTML
 </script>
 
-<MarkDownPage {readmeHTML} title="About LibreLingo" />
+<MarkDownPage {readmeHTML} title="About LibreLingo" description="{$_('about.meta.description')}" />

--- a/workspaces/web/src/routes/development.svelte
+++ b/workspaces/web/src/routes/development.svelte
@@ -30,6 +30,7 @@
 
 <svelte:head>
   <title>LibreLingo - Development</title>
+  <meta name="description" content="{$_('development.meta.description')}"/>
 </svelte:head>
 
 {#if issues === null}

--- a/workspaces/web/src/routes/index.svelte
+++ b/workspaces/web/src/routes/index.svelte
@@ -10,6 +10,7 @@
 
 <svelte:head>
   <title>{$_('meta.title')}</title>
+  <meta name="description" content="{$_('index.meta.description')}"/>
 </svelte:head>
 
 <section class="hero is-bold is-fullheight">

--- a/workspaces/web/src/routes/sign-up-success.svelte
+++ b/workspaces/web/src/routes/sign-up-success.svelte
@@ -10,7 +10,7 @@
 
 <section class="section">
   <div class="container">
-    <h2 class="is-size-2">Registration successsful!</h2>
+    <h2 class="is-size-2">Registration successful!</h2>
     <p>You can now log in.</p>
     <Button href="/login">Log in</Button>
   </div>

--- a/workspaces/web/src/routes/sign-up.svelte
+++ b/workspaces/web/src/routes/sign-up.svelte
@@ -4,6 +4,7 @@
   import NavBar from "../components/NavBar.svelte"
   import Button from "lluis/Button"
   import FormField from "lluis/FormField"
+  import { _ } from "svelte-i18n"
 
   let loading = false
 
@@ -188,6 +189,7 @@
 
 <svelte:head>
   <title>Sign up - LibreLingo</title>
+  <meta name="description" content="{$_('sign-up.meta.description')}"/>
 </svelte:head>
 
 <NavBar dark />

--- a/workspaces/web/src/translation/en.json
+++ b/workspaces/web/src/translation/en.json
@@ -3,5 +3,9 @@
     "index.start_spanish_course": "Start learning Spanish",
     "index.start_german_course": "Start learning German",
     "index.about_librelingo": "About LibreLingo",
-    "meta.title": "LibreLingo - learn a language for free"
+    "index.meta.description": "LibreLingo is an experiment to create a community driven language-learning platform. Learn a language for free.",
+    "meta.title": "LibreLingo - learn a language for free",
+    "about.meta.description": "LibreLingo is an open source, community-driven language-learning platform that gives its users and contributors a way to influence its future.",
+    "development.meta.description": "Read about the recent major new features in LibreLingo, an experiment to create a community driven language-learning platform.",
+    "sign-up.meta.description": "Sign up to LibreLingo and learn a language for free."
 }


### PR DESCRIPTION
Add meta description to the head of the index, about, development and sign-up pages.

Fixes #185