### PR TITLE
feat: set up typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,12 @@
   },
   "devDependencies": {
     "eslint": "6.8.0",
-    "eslint-plugin-jest": "24.0.2",
     "eslint-plugin-cypress": "2.11.2",
-    "eslint-plugin-svelte3": "2.7.3"
+    "eslint-plugin-jest": "24.0.2",
+    "eslint-plugin-svelte3": "2.7.3",
+    "svelte": "^3.29.0",
+    "svelte-preprocess": "^4.3.2",
+    "typescript": "^4.0.3"
   },
   "nyc": {
     "report-dir": "cypress-coverage",
@@ -55,5 +58,9 @@
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true
+  },
+  "dependencies": {
+    "source-map-loader": "^1.1.0",
+    "ts-loader": "^8.0.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "Svelte",
+  
+    "compilerOptions": {
+        "moduleResolution": "node",
+        "target": "es2017",
+        /** 
+        Svelte Preprocess cannot figure out whether you have a value or a type, so tell TypeScript
+        to enforce using `import type` instead of `import` for Types.
+        */
+        "importsNotUsedAsValues": "error",
+        "isolatedModules": true,
+        /**
+        To have warnings/errors of the Svelte compiler at the correct position,
+        enable source maps by default.
+        */
+        "sourceMap": true,
+        /** Requests the runtime types from the svelte modules by default. Needed for TS files or else you get errors. */
+        "types": ["svelte"],
+
+        "strict": false,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/workspaces/lluis/Button.svelte
+++ b/workspaces/lluis/Button.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { createEventDispatcher } from "svelte"
 
   const dispatch = createEventDispatcher()
@@ -73,7 +73,7 @@
   {/if}
 {/if}
 
-<style>
+<style type="text/scss">
   .button.customColor {
     background-color: var(--color);
   }

--- a/workspaces/lluis/ClampedText.svelte
+++ b/workspaces/lluis/ClampedText.svelte
@@ -1,10 +1,10 @@
-<script>
+<script lang="typescript">
   export let text
 </script>
 
 <p class="is-6 clamp">{text}</p>
 
-<style>
+<style type="text/scss">
   .clamp {
     display: -webkit-box;
     -webkit-box-orient: vertical;

--- a/workspaces/lluis/Column.svelte
+++ b/workspaces/lluis/Column.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let size = null
   export let sizeDesktop = null
   export let sizeTablet = null

--- a/workspaces/lluis/Columns.svelte
+++ b/workspaces/lluis/Columns.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let multiline = false
   export let reversed = false
 </script>
@@ -10,7 +10,7 @@
   <slot />
 </div>
 
-<style>
+<style type="text/scss">
   @import './node_modules/bulma/sass/utilities/_all';
 
   @include until($tablet) {

--- a/workspaces/lluis/FormField.svelte
+++ b/workspaces/lluis/FormField.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Icon from "lluis/Icon.svelte"
 
   export let name

--- a/workspaces/lluis/Icon.svelte
+++ b/workspaces/lluis/Icon.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let size = "medium"
   export let prefix = "fas"
   export let icon

--- a/workspaces/web/src/components/ChallengePanel.svelte
+++ b/workspaces/web/src/components/ChallengePanel.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { slide } from "svelte/transition"
   import Button from "lluis/Button"
 

--- a/workspaces/web/src/components/ChallengeScreen.svelte
+++ b/workspaces/web/src/components/ChallengeScreen.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import sound from "../media/sound"
   import DeckChallenge from "./DeckChallenge"
   import OptionChallenge from "./OptionChallenge"
@@ -159,7 +159,7 @@
   </div>
 {/if}
 
-<style>
+<style type="text/scss">
   .section {
     padding: 1.5em;
   }

--- a/workspaces/web/src/components/ChipsChallenge/index.svelte
+++ b/workspaces/web/src/components/ChipsChallenge/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import Sortable from "sortablejs"
   import hotkeys from "hotkeys-js"
@@ -171,7 +171,7 @@
   {/if}
 </form>
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .chip {

--- a/workspaces/web/src/components/DeckChallenge/index.svelte
+++ b/workspaces/web/src/components/DeckChallenge/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"

--- a/workspaces/web/src/components/FanfareScreen.svelte
+++ b/workspaces/web/src/components/FanfareScreen.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { scale } from "svelte/transition"
   import db from "../db/db"
   import savePractice from "../db/skill/savePractice"
@@ -62,7 +62,7 @@
   </div>
 </section>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   @include from($tablet) {

--- a/workspaces/web/src/components/GitHubButton.svelte
+++ b/workspaces/web/src/components/GitHubButton.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   export async function preload(page) {
     const repo = await fetch("https://api.github.com/repos/kantord/LibreLingo")
 
@@ -9,7 +9,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import Icon from "lluis/Icon"
   import Button from "lluis/Button"
@@ -54,7 +54,7 @@
   <span class="is-hidden-mobile">GitHub</span>
 </Button>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .tag {

--- a/workspaces/web/src/components/InputFieldWithVirtualKeyboard.svelte
+++ b/workspaces/web/src/components/InputFieldWithVirtualKeyboard.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Button from "lluis/Button"
   export let value
   export let specialCharacters
@@ -83,7 +83,7 @@
   {/each}
 </div>
 
-<style>
+<style type="text/scss">
   .keyboard {
     margin-top: 2em;
   }

--- a/workspaces/web/src/components/LicenseLogo.svelte
+++ b/workspaces/web/src/components/LicenseLogo.svelte
@@ -2,7 +2,7 @@
   src="images/agpl-logo.svg"
   alt="Licensed under AGPL - Free as in Freedom" />
 
-<style>
+<style type="text/scss">
   img {
     height: 2.5em;
     mix-blend-mode: multiply;

--- a/workspaces/web/src/components/ListeningChallenge.svelte
+++ b/workspaces/web/src/components/ListeningChallenge.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import levenshtein from "js-levenshtein"

--- a/workspaces/web/src/components/MarkDownPage.svelte
+++ b/workspaces/web/src/components/MarkDownPage.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   export async function getMarkDownData(markdownModule) {
     const remark = await require("remark")
     const markdown = await import("remark-parse")
@@ -15,7 +15,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import NavBar from "../components/NavBar"
 
   export let readmeHTML

--- a/workspaces/web/src/components/Mascot.svelte
+++ b/workspaces/web/src/components/Mascot.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let shadow = true
   export let glow = false
   let imageURL =
@@ -9,7 +9,7 @@
 
 <img data-test="mascot-jetpack" src="{imageURL}" alt="" class:glow />
 
-<style>
+<style type="text/scss">
   .glow {
     filter: drop-shadow(0 0 2em #ffffff1c);
   }

--- a/workspaces/web/src/components/NavBar.svelte
+++ b/workspaces/web/src/components/NavBar.svelte
@@ -1,4 +1,5 @@
-<script>
+<script lang="typescript">
+
   import settings from "../settings"
   import authStore from "../auth"
   import GitHubButton from "./GitHubButton"
@@ -55,7 +56,7 @@
   </div>
 </nav>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .navbar.dark {

--- a/workspaces/web/src/components/Option.svelte
+++ b/workspaces/web/src/components/Option.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let active
   export let inactive
   export let correct
@@ -18,7 +18,7 @@
   </div>
 </li>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .option {

--- a/workspaces/web/src/components/OptionCard.svelte
+++ b/workspaces/web/src/components/OptionCard.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let active
   export let inactive
   export let number
@@ -29,7 +29,7 @@
   </div>
 </li>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .card {

--- a/workspaces/web/src/components/OptionChallenge/index.svelte
+++ b/workspaces/web/src/components/OptionChallenge/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"

--- a/workspaces/web/src/components/OptionDeck.svelte
+++ b/workspaces/web/src/components/OptionDeck.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"
@@ -44,7 +44,7 @@
   {/each}
 </ul>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .options {

--- a/workspaces/web/src/components/Options.svelte
+++ b/workspaces/web/src/components/Options.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"
@@ -35,7 +35,7 @@
   {/each}
 </ul>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .options {

--- a/workspaces/web/src/components/Phrase.svelte
+++ b/workspaces/web/src/components/Phrase.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let phrase
 </script>
 
@@ -12,7 +12,7 @@
   {/each}
 </b>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .phrase span {

--- a/workspaces/web/src/components/ProgressBar.svelte
+++ b/workspaces/web/src/components/ProgressBar.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { tweened } from "svelte/motion"
 
   export let value
@@ -13,7 +13,7 @@
   </progress>
 </div>
 
-<style>
+<style type="text/scss">
   @import "../variables";
   div {
     padding-bottom: $size-6;

--- a/workspaces/web/src/components/ShortInputChallenge.svelte
+++ b/workspaces/web/src/components/ShortInputChallenge.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"
   import shuffle from "lodash.shuffle"
@@ -123,7 +123,7 @@
 
 </form>
 
-<style>
+<style type="text/scss">
   .card {
     max-width: 16em;
     margin: auto;

--- a/workspaces/web/src/components/SkillCard/Buttons.svelte
+++ b/workspaces/web/src/components/SkillCard/Buttons.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Button from "lluis/Button"
 
   export let practiceHref

--- a/workspaces/web/src/components/SkillCard/ContentCenter.svelte
+++ b/workspaces/web/src/components/SkillCard/ContentCenter.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Summary from "./Summary"
 
   export let title
@@ -20,7 +20,7 @@
   {/if}
 </div>
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .completed,

--- a/workspaces/web/src/components/SkillCard/ContentLeft.svelte
+++ b/workspaces/web/src/components/SkillCard/ContentLeft.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import ImageSet from "./ImageSet"
 
   export let imageSet
@@ -14,7 +14,7 @@
   </div>
 {/if}
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .stale,

--- a/workspaces/web/src/components/SkillCard/ImageSet.svelte
+++ b/workspaces/web/src/components/SkillCard/ImageSet.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let imageSet
   export let completed
   export let stale
@@ -10,7 +10,7 @@
   <img src="{`images/${imageSet[2]}_tiny.jpg`}" alt="" />
 </figure>
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .image-set {

--- a/workspaces/web/src/components/SkillCard/Summary.svelte
+++ b/workspaces/web/src/components/SkillCard/Summary.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import ClampedText from "lluis/ClampedText"
 
   export let summary
@@ -10,7 +10,7 @@
   <ClampedText text="{`Learn: ${summary.join(', ')}`}" />
 </div>
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .completed,

--- a/workspaces/web/src/components/SkillCard/index.svelte
+++ b/workspaces/web/src/components/SkillCard/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import { onDestroy, onMount } from "svelte"
 
   import live from "../../db/live"
@@ -78,7 +78,7 @@
   </footer>
 </div>
 
-<style>
+<style type="text/scss">
   @import "../../variables";
 
   .card-content {

--- a/workspaces/web/src/components/TwitterButton.svelte
+++ b/workspaces/web/src/components/TwitterButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Button from "lluis/Button"
   import Icon from "lluis/Icon"
 </script>

--- a/workspaces/web/src/routes/_error.svelte
+++ b/workspaces/web/src/routes/_error.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   export let status
   export let error
 
@@ -17,7 +17,7 @@
   <pre>{error.stack}</pre>
 {/if}
 
-<style>
+<style type="text/scss">
   h1,
   p {
     margin: 0 auto;

--- a/workspaces/web/src/routes/_layout.svelte
+++ b/workspaces/web/src/routes/_layout.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   import { waitLocale } from "svelte-i18n"
   import authStore from "../auth"
 
@@ -7,7 +7,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import settings from "../settings"
 
   export let segment

--- a/workspaces/web/src/routes/about.svelte
+++ b/workspaces/web/src/routes/about.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   import MarkDownPage, { getMarkDownData } from "../components/MarkDownPage"
   import { _ } from "svelte-i18n"
 
@@ -11,7 +11,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   export let readmeHTML
 </script>
 

--- a/workspaces/web/src/routes/course/[courseName]/index.svelte
+++ b/workspaces/web/src/routes/course/[courseName]/index.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   export async function preload(page, session) {
     const { courseName } = page.params
     const { modules, languageName } = await import(
@@ -9,7 +9,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import SkillCard from "../../../components/SkillCard"
   import NavBar from "../../../components/NavBar.svelte"
   import Column from "lluis/Column.svelte"
@@ -71,7 +71,7 @@
   </div>
 </footer>
 
-<style>
+<style type="text/scss">
   @import "../../../variables";
   .container {
     padding-right: 20px;

--- a/workspaces/web/src/routes/course/[courseName]/skill/[id].svelte
+++ b/workspaces/web/src/routes/course/[courseName]/skill/[id].svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   export async function preload(page, session) {
     const { id, courseName } = page.params
     const {
@@ -28,7 +28,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import ChallengeScreen from "../../../../components/ChallengeScreen"
   import NavBar from "../../../../components/NavBar"
   import { sortChallengeGroups } from "./_logic"

--- a/workspaces/web/src/routes/development.svelte
+++ b/workspaces/web/src/routes/development.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import NavBar from "../components/NavBar"
   import Mascot from "../components/Mascot"
   import TwitterButton from "../components/TwitterButton"
@@ -228,7 +228,7 @@
   </section>
 {/if}
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .card {

--- a/workspaces/web/src/routes/devtools.svelte
+++ b/workspaces/web/src/routes/devtools.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   export async function preload(page, session) {
     if (!process.browser) {
       const fs = require("fs")
@@ -14,7 +14,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   import NavBar from "../components/NavBar"
   import Mascot from "../components/Mascot"
   import TwitterButton from "../components/TwitterButton"

--- a/workspaces/web/src/routes/index.svelte
+++ b/workspaces/web/src/routes/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import Mascot from "../components/Mascot"
   import LicenseLogo from "../components/LicenseLogo"
   import Button from "lluis/Button"
@@ -54,7 +54,7 @@
   <LicenseLogo />
 </div>
 
-<style>
+<style type="text/scss">
   @import "../variables";
 
   .title img {

--- a/workspaces/web/src/routes/license.svelte
+++ b/workspaces/web/src/routes/license.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   import MarkDownPage, { getMarkDownData } from "../components/MarkDownPage"
 
   export async function preload(page, session) {
@@ -10,7 +10,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   export let readmeHTML
 </script>
 

--- a/workspaces/web/src/routes/login.svelte
+++ b/workspaces/web/src/routes/login.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import db from "../db/db.js"
   import NavBar from "../components/NavBar.svelte"
   import Button from "lluis/Button"

--- a/workspaces/web/src/routes/sign-up-success.svelte
+++ b/workspaces/web/src/routes/sign-up-success.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import db from "../db/db.js"
   import { onMount } from "svelte"
   import hotkeys from "hotkeys-js"

--- a/workspaces/web/src/routes/sign-up.svelte
+++ b/workspaces/web/src/routes/sign-up.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="typescript">
   import db from "../db/db.js"
   import settings from "../settings"
   import NavBar from "../components/NavBar.svelte"

--- a/workspaces/web/src/routes/tos.svelte
+++ b/workspaces/web/src/routes/tos.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script lang="typescript" context="module">
   import MarkDownPage, { getMarkDownData } from "../components/MarkDownPage"
 
   export async function preload(page, session) {
@@ -10,7 +10,7 @@
   }
 </script>
 
-<script>
+<script lang="typescript">
   export let readmeHTML
 </script>
 

--- a/workspaces/web/webpack.config.js
+++ b/workspaces/web/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path")
 const config = require("sapper/config/webpack.js")
 const pkg = require("./package.json")
 const MiniCssExtractPlugin = require("mini-css-extract-plugin")
-const sass = require("svelte-preprocess-sass").sass
+const {typescript, sass} = require("svelte-preprocess")
 const CopyPlugin = require("copy-webpack-plugin")
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
     .BundleAnalyzerPlugin
@@ -12,7 +12,7 @@ const mode = process.env.NODE_ENV
 const dev = mode === "development"
 
 const alias = { svelte: path.resolve("node_modules", "svelte") }
-const extensions = [".mjs", ".js", ".json", ".svelte", ".html"]
+const extensions = [".mjs", ".js", ".ts", ".json", ".svelte", ".html"]
 const mainFields = ["svelte", "module", "browser", "main"]
 
 module.exports = {
@@ -63,14 +63,21 @@ module.exports = {
                     use: {
                         loader: "svelte-loader",
                         options: {
-                            preprocess: {
-                                style: sass({}, { all: true }),
-                            },
+                            preprocess: [
+                                // TO-DO: config?
+                                typescript({}),
+                                sass({}),
+                            ],
                             dev,
                             hydratable: true,
                             hotReload: false, // pending https://github.com/sveltejs/svelte/issues/2377
                         },
                     },
+                },
+                // TO-DO: config?
+                { 
+                    test: /\.ts$/, 
+                    loader: "ts-loader" ,
                 },
             ],
         },
@@ -117,14 +124,21 @@ module.exports = {
                     use: {
                         loader: "svelte-loader",
                         options: {
-                            preprocess: {
-                                style: sass({}, { all: true }),
-                            },
+                            preprocess: [
+                                // TO-DO: config?
+                                typescript({}),
+                                sass({}),
+                            ],
                             css: false,
                             generate: "ssr",
                             dev,
                         },
                     },
+                },
+                // TO-DO: config?
+                { 
+                    test: /\.ts$/, 
+                    loader: "ts-loader" ,
                 },
             ],
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,18 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.0.tgz#dc85454b953178cc6043df5208b9e949b54a3bc4"
   integrity sha512-/rM+sWiuOZ5dvuVzV37sUuklsbg+JPOP8d+nNFlo2ZtfpzPiPvh1/gc8liWOLBqe+sR+ZM7guPaIcTt6UZTo7Q==
 
+"@types/pug@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+  integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
+
+"@types/sass@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.0.tgz#b41ac1c17fa68ffb57d43e2360486ef526b3d57d"
+  integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sinon-chai@3.2.3":
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.3.tgz#afe392303dda95cc8069685d1e537ff434fa506e"
@@ -2801,6 +2813,11 @@ abab@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
   integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
+abab@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 abbrev@1:
   version "1.1.1"
@@ -3956,7 +3973,7 @@ chai@^4.2.0:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5157,7 +5174,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-indent@6.0.0:
+detect-indent@6.0.0, detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
@@ -5403,19 +5420,19 @@ end-stream@~0.1.0:
   dependencies:
     write-stream "~0.4.3"
 
-enhanced-resolve@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz#5d43bda4a0fd447cb0ebbe71bef8deff8805ad0d"
-  integrity sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
+  integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
-  integrity sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==
+enhanced-resolve@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.2.0.tgz#5d43bda4a0fd447cb0ebbe71bef8deff8805ad0d"
+  integrity sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
@@ -7047,6 +7064,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -8573,7 +8597,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9000,7 +9024,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -9052,6 +9076,11 @@ mimic-fn@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
   integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
@@ -11117,7 +11146,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -11502,6 +11531,18 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-loader@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-1.1.0.tgz#f0fcc88106137793a89ec00f118196b601f111ae"
+  integrity sha512-Kj7rXntLhAsEjZlqGz85Mbnu8N4gcxj5qZI1XyLQjqAI/p92ckRXwErb3jVYL5JxlFJnD4VgwybpB1h6NlETRg==
+  dependencies:
+    abab "^2.0.4"
+    iconv-lite "^0.6.2"
+    loader-utils "^2.0.0"
+    schema-utils "^2.7.0"
+    source-map "^0.6.1"
+    whatwg-mimetype "^2.3.0"
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -11972,6 +12013,13 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
@@ -12086,7 +12134,17 @@ svelte-preprocess-sass@0.2.0:
   dependencies:
     svelte-preprocess-filter "^1.0.0"
 
-svelte@3.29.0:
+svelte-preprocess@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.3.2.tgz#a05a98e59c64044e835b1401346be41665f19971"
+  integrity sha512-CmIsCr62y34qGS10/SC1l1VkmX0kZR6wncbGgRJ1qJftLDMEaazC3bWqoqAlrqyQFvpO0+xb44GQm4RKi/9sLQ==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
+
+svelte@3.29.0, svelte@^3.29.0:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.29.0.tgz#80acac4254341ad8f3301e5ef03f4127ea967d96"
   integrity sha512-f+A65eyOQ5ujETLy+igNXtlr6AEjAQLYd1yJE1VwNiXMQO5Z/Vmiy3rL+zblV/9jd7rtTTWqO1IcuXsP2Qv0OA==
@@ -12440,6 +12498,17 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-loader@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.4.tgz#02b9c91fbcfdb3114d8b1e98a3829265270eee7a"
+  integrity sha512-5u8KF1SW8eCUb/Ff7At81e3wznPmT/27fvaGRO9CziVy+6NlPVRvrzSox4OwU0/e6OflOUB32Err4VquysCSAQ==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 tslib@^1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -12530,6 +12599,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 uglify-js@^3.5.1:
   version "3.8.0"


### PR DESCRIPTION
#722 

## Changes

- Added typescript support to `.svelte` files using `svelte-preprocess` in `webpack.config.js`.
- (Forgetting about the "What is not required" section of the original issue) Changed added `lang="typescript"` and  `type="text/scss"` to `<script>` and `<style>` tags in the `.svelte` files.
- Added `ts-loader` to webpack so that `.js` files can be converted to `.ts`.
- Added `tsconfig.json` (copied from [here](https://github.com/tsconfig/bases/blob/master/bases/svelte.json)).

## Testing

- With the changes made, nothing breaks right now. I also made sure that typescript actually works by pasting a snippet from [here](https://www.typescriptlang.org/docs/handbook/generics.html) into the `<script>` tags. I also converted a `.js` file into `.ts`, pasted the snippet, and ran `yarn web dev`. Both cases returned no errors.

## Issues

- Need to look at `tsconfig.json` and the "TO-DO"s (ctrl+f) in `webpack.config,js`, and update them if necessary.
- [This line](https://github.com/kantord/LibreLingo/blob/master/workspaces/answer-corrector/index.js#L60) returned an error because the function doesn't contain `alwaysSuggest` as an argument. This code works when its `.js` but breaks in `.ts`. I think there might be some compiler option to fix this.

