### PR TITLE
docs: remove 'want to help naming mascot?' from the development page

### DIFF
--- a/workspaces/web/src/routes/development.svelte
+++ b/workspaces/web/src/routes/development.svelte
@@ -94,13 +94,6 @@
                   Caroline Delesalle
                 </a>
               </h3>
-              <p>
-                <a
-                  href="https://github.com/kantord/LibreLingo/issues/367"
-                  class="link">
-                  Want to help naming it?
-                </a>
-              </p>
             </div>
           </div>
         </Column>


### PR DESCRIPTION
fixes #1012 