### PR TITLE
docs: make courses docs beginner friendly

### DIFF
--- a/docs/courses/README.md
+++ b/docs/courses/README.md
@@ -1,28 +1,104 @@
-# Contributing to LibreLingo courses
+# LibreLingo Course Documentation
 
-LibreLingo courses consist of files that contain course content. These files
-are organized in a specific directory structure.
-[Learn how to edit or create courses](editing-courses.md)!
+This document describes how LibreLingo's course system works and how to contribute to course content.
 
+Understanding this document is the first step if you want to:
+- edit or improve an existing course
+- contribute a new accepted answer
+- create a new course from scratch
+
+This is also a good resource if you just want to learn about the course system in general.
+
+---
+
+**Confused?**
+[Ask people](https://github.com/kantord/LibreLingo/discussions) on GitHub Discussions.
+
+---
+
+**Table of Contents:**
+- [Getting started](#getting-started)
+- [Basics](#basics)
+  - [Terminology](#terminology)
+  - [Exploring the courses](#exploring-courses)
+  - [Things to do for new contributors](#things-new-contributors)
+- [Courses currently open for contributions](#courses-open)
+  - [For English speakers](#courses-from-english)
+- [Caution](#caution)
+  - [Languages that don't use the Latin alphabet](#non-latin-alphabet)
+
+## Getting started
+
+- Totally new to LibreLingo? Head to the [Basics](#basics) section! It will give you a general understanding of the course system.
+- Want to edit or improve existing courses? Check out [this page about editing courses](editing-courses.md).
+- If you want to create new courses (typically suited for course designers or advanced users), go to [this page](creating-courses.md).
+
+
+## Basics
+
+### Terminology
+
+You'll need to have an idea on basic terminology used in LibreLingo:
+
+- A **Course** is a set of Modules. There is typically one course for each language pair. e.g. Spanish for English speakers, Japanese for Italian speakers, etc.
+- A **Module** is a set of Skills.
+- A **Skill** is a small unit of course material. In the web app, the user will typically practice a Skill at a time.
+
+These concepts represent a hierarchical structure to LibreLingo course material: `Courses > Modules > Skills`
+
+- The **target language** is the language the course is meant to teach.
+- The **source langauge** is a language that users of the course are assumed to know.
+
+
+<a id="exploring-courses"></a>
+### Exploring the courses
+
+To have a better understanding of how courses work, you can explore how the course files are organized on this repository.
+
+You will find courses in the `courses` directory of [LibreLingo's repository](https://github.com/kantord/LibreLingo/tree/main/courses). The course directory name is usually structured in `<destination language>-from-<target audience's language>`. e.g. `french-from-english` teaches French to English speakers. In each course you'll find modules. And in each module you'll find skills, which are saved as individual .yaml files.
+
+Now let's look into how they look on the frontend, to the user.
+
+Go to [LibreLingo web app](https://librelingo.app/). Courses are listed there. e.g. You see a "START LEARNING SPANISH" button. (**NOTE:** Depending on the state and completeness of the courses, all of them might not be shown there on the website.)
+
+When you enter a course page, for example the [Spanish course](https://librelingo.app/course/spanish-from-english/), you'll see headings like Basics, Introduction, Activities. These are modules. Each module contains a set of skills. Modules organize skills into groups, which is their only purpose. Think of them as groups of units or chapters.
+
+"Skills" are units of course content focused on a particular topic. Each skill is a set of new knowledge, such as new words or phrases.  Skills can focus on vocabulary and follow a theme: the "Animal" skill has words and phrases related to animals, the "Food" skill is all about food. Skills can also focus on teaching grammar.
+
+Inside a skill YAML file there are some keys that you might want to learn of, which is exaplained in detail [here](course.md).
+
+<a id="things-new-contributors"></a>
+### Things you can do as a new contributor
+
+If you are new in contributing to course data, these are the things you can do to get a proper understanding of the courses and have a good time with the project:
+
+- Go to [LibreLingo's Spanish course](https://librelingo.app/course/spanish-from-english) and try out some of the skills. Just get an idea on how the questions are structured and the type of answers made available.
+- [Browse this repository](https://github.com/kantord/LibreLingo/) or [download it](https://github.com/kantord/LibreLingo/archive/main.zip) and study the `courses` directory and how everything's laid out. Be sure to have a good text editor, such as [Notepad++](https://notepad-plus-plus.org/), [Geany](https://geany.org/) in hand to view or edit files.
+- Try to learn how data is organized within .yaml files and directories. [Course](course.md), [Module](module.md) and [Skill](skill.md) documentation may help you on this.
+- Try to learn how YAML works. (see [here](https://en.wikipedia.org/wiki/YAML#Syntax) or [here](https://blog.stackpath.com/yaml/) or [here](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/))
+- Determine some information about the language you're working with.
+  - Your language name in English. e.g. French, Ancient Greek
+  - Language slug (lowercase and no spaces). e.g. french, ancient-greek
+  - IETF BCP 47 tag name for your language, which you can get from [here](http://www.iana.org/assignments/language-subtag-registry). Just look for the `Subtag` for your language. e.g. fr, grc
+- If you have questions, feel free to ask on [Discussions](https://github.com/kantord/LibreLingo/discussions).
+
+
+<a id="courses-open"></a>
 ## Courses currently open for contributions
 
+<a id="courses-from-english"></a>
 ### For English speakers
 
 - [Spanish for English speakers](https://github.com/kantord/LibreLingo/tree/master/courses/spanish-from-english) ([Preview](https://librelingo.app/course/spanish-from-english/))
 - [German for English speakers](https://github.com/kantord/LibreLingo/tree/master/courses/german-from-english) ([Preview](https://librelingo.app/course/german-from-english/))
 - [French for English speakers](https://github.com/kantord/LibreLingo/tree/master/courses/french-from-english)
+- [Bangla for English speakers](https://github.com/kantord/LibreLingo/tree/master/courses/bangla-from-english)
 
-## Creating a new course
 
-Before creating a new course, it's recommended that you first contribute to
-existing courses. [Learn how to edit or create courses](editing-courses.md). In order to create a
-new course and get it published, you'll probably need some technical assistance
-as at this stage, several things might not be automated.
+## Caution
 
-You can start off by creating your pull request. I'll get to help with the
-pull requests as soon as possible.
-
-## Languages that don't use the Latin alphabet
+<a id="non-latin-alphabet"></a>
+### Languages that don't use the Latin alphabet
 
 Currently LibreLingo doesn't have enough features to support teaching new
 alphabets. Solving this is a priority, but will take time. Technically in most

--- a/docs/courses/course.md
+++ b/docs/courses/course.md
@@ -1,0 +1,113 @@
+# LibreLingo Documentation on Course
+
+A **Course** is the highest element on the course structure. It contains modules, which in turn contains skills. There are usually one course for each language.
+
+To get a better understanding, you can explore the [`courses` directory](https://github.com/kantord/LibreLingo/tree/main/courses) on this repository and read the [course basics](README.md#basics).
+
+---
+
+**Confused?**
+[Ask people](https://github.com/kantord/LibreLingo/discussions) on GitHub Discussions.
+
+---
+
+**Table of Contents:**
+- [Tree structure](#tree-structure)
+- [`course.yaml`](#yaml)
+  - [Data breakdown](#data-breakdown)
+
+## Tree structure
+
+A typical tree structure for a course is like this:
+
+```
+courses/spanish-from-english/
+├── activities
+│   ├── module.yaml
+│   └── skills
+│       ├── continuous.yaml
+│       └── ser_estar.yaml
+├── basics
+│   ├── module.yaml
+│   └── skills
+│       ├── animals.yaml
+│       ├── clothes.yaml
+│       ├── food.yaml
+│       ├── nature.yaml
+│       ├── plurals.yaml
+│       ├── professions.yaml
+│       ├── verb_plurals.yaml
+│       └── verbs.yaml
+├── course.yaml
+└── introduction
+    ├── module.yaml
+    └── skills
+        ├── adjectives.yaml
+        ├── phrases.yaml
+        └── preferences.yaml
+```
+
+Here, `activities`, `basics` and `introduction` are [modules](module.md). The `continuous.yaml`, `animals.yaml` etc. are [skills](skill.md). Directly inside the course directory there is also a file called `course.yaml`. This file contains information about the course ([see below](#yaml)).
+
+A course directory name should not have spaces and should be written in `slug-form` in plain English.
+
+<a id="yaml"></a>
+## `course.yaml`
+
+A `course.yaml` file for the Spanish course looks like this:
+
+```yaml
+# This file contains generic meta-data about the course
+
+Course:
+  Language:
+    Name: Spanish
+    IETF BCP 47: es
+  For speakers of:
+    Name: English
+    IETF BCP 47: en
+  License:
+    Name: Attribution-ShareAlike 4.0 International
+    Short name: CC BY-SA 4.0
+    Link: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  Special characters:
+    - "á"
+    - "Á"
+    - "é"
+    - "É"
+    - "í"
+    - "Í"
+    - "ó"
+    - "Ó"
+    - "ú"
+    - "Ú"
+    - "ü"
+    - "Ü"
+    - "ñ"
+    - "Ñ"
+    - "¿"
+    - "¡"
+
+Modules:
+  - basics/
+  - introduction/
+  - activities/
+```
+
+<a id="data-breakdown"></a>
+### Data breakdown
+
+**`Course`** has information about the course.
+- `Language`
+  - `Language > Name`: The name of the language you want to test for or teach.
+  - `Language > IETF BCP 47`: The IETF BCP 47 code of the above language. List available [here](http://www.iana.org/assignments/language-subtag-registry).
+- `For speakers of`
+  - `For speakers of > Name`: The name of the language your target audience already speaks.
+  - `For speakers of > IETF BCP 47`: The IETF BCP 47 code of the above language. List available [here](http://www.iana.org/assignments/language-subtag-registry).
+- `License`
+  - `License > Name`: Full license name under which your course is made available. In most cases it's ok to keep it as is.
+  - `License > Short name`: Short name for the license. e.g. `CC BY-SA 4.0`
+  - `License > Link`: URL to reach to the full text of the license. e.g. `https://creativecommons.org/licenses/by-sa/4.0/legalcode`
+- `Special characters`: An array of special characters that might not be present on a typical English keyboard.
+
+**`Modules`** has a list of module directory names followed by a `/`.

--- a/docs/courses/creating-courses.md
+++ b/docs/courses/creating-courses.md
@@ -1,0 +1,19 @@
+## Creating a new LibreLingo course
+
+Before creating a new course, we recommend you try contributing to an existing one or at least exploring other parts of this documentation. In order to be successful in creating a new course from scratch, you'll need sufficient understanding of the project and how the courses work.
+
+---
+
+**WARNING**: If you just want to make any existing course to be available on your language, please refer to [this page](editing-courses.md) instead and ignore this page. Following this page for editing existing courses can cause invalid data to be created.
+
+---
+
+[TODO: Add more text on how to create a course from scratch possibly with cli tool etc.]
+
+Before creating a new course, it's recommended that you first contribute to
+existing courses. [Learn how to edit or create courses](editing-courses.md). In order to create a
+new course and get it published, you'll probably need some technical assistance
+as at this stage, several things might not be automated.
+
+You can start off by creating your pull request. I'll get to help with the
+pull requests as soon as possible.

--- a/docs/courses/editing-courses.md
+++ b/docs/courses/editing-courses.md
@@ -1,183 +1,153 @@
-# Creating and editing LibreLingo courses
+# Editing LibreLingo courses
 
-LibreLingo courses consist of files that contain course content. These files
-are organized in a specific directory structure.
+Thank you for your interest in contributing to LibreLingo. This document is here to guide you for editing or translating existing courses.
 
-A simplified example of the directory structure of a LibreLingo course:
+To get a better understanding, we recommend you read the [course basics](README.md#basics) first.
 
-```
-courses/french-from-english/
-courses/french-from-english/basics
-courses/french-from-english/basics/module.yaml
-courses/french-from-english/basics/skills
-courses/french-from-english/basics/skills/hello.yaml
-courses/french-from-english/course.yaml
-```
+---
 
-LibreLingo courses can be published in different formats. One such format is
-the LibreLingo web app.
+**Confused?**
+[Ask people](https://github.com/kantord/LibreLingo/discussions) on GitHub Discussions.
 
-When you are working with LibreLingo courses, you'll be mostly editing the
-`.yaml` files as seen above. The standard way of editing LibreLingo courses is
-using GitHub.
+---
 
-If you don't know how to use GitHub, it might be useful to check out these
-guides:
+**Table of Contents:**
+- [Setup](#setup)
+  - [Pulling code and branching](#pulling-and-branching)
+  - [Pushing code and creating Pull Request](#pushing-and-pr)
+  - [Following up with responses](#following-up-pr)
+- [Translating based on an existing course](#translating)
+- [Editing existing courses](#editing-existing)
 
-- [Creating new files on GitHub](https://docs.github.com/en/github/managing-files-in-a-repository/creating-new-files)
-- [Editing files on GitHub](https://docs.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository)
+## Setup
 
-## Editing skills
+<a id="pulling-and-branching"></a>
+### Pulling code and branching
 
-If you are contributing to existing courses, the thing you are most likely
-to do is edit existing skills.
+LibreLingo uses Git repository for maintaining code. In order to contribute changes, you need to first fork this project. To fork:
+- [login](https://github.com/login) to GitHub
+- then go to [LibreLingo repository](https://github.com/kantord/LibreLingo/)
+- click the "Fork" button (beside Watch and Star)
 
-Skills are written as YAML files with a specific structure. From our example
-above, the YAML file corresponding to the "hello" skill would be
-`courses/french-from-english/basics/skills/hello.yaml`.
+In a moment you will be taken to a new repository. Closely notice the url as it will be `https://github.com/<your github username>/LibreLingo/` instead of `https://github.com/kantord/LibreLingo/`. Now you should have a copy of the project source code under your name.
 
-The structure of `hello.yaml` is as follows:
+This is called "[forking](https://guides.github.com/activities/forking/)". Forking allows you to apply your changes without directly changing the original project.
 
-```yaml
-Skill:
-  Id: 33bfee7d-de74-4362-bf15-ce165add2dc8
-  Name: Hello
-  Thumbnails:
-    - people1
-    - woman1
-    - man1
+Now click the Green "Code" button and copy the HTTPS clone URL.
 
-New words:
-  - Word: l'homme
-    Translation: the man
-    Images:
-      - man1
-      - man2
-      - man3
+Make sure you have Git installed on your computer. If not, follow [these instructions](https://www.linode.com/docs/guides/how-to-install-git-on-linux-mac-and-windows/) to install it on your operating system.
 
-  - Word: la femme
-    Synonyms:
-      - la dame
-    Translation: the woman
-    Also accepted:
-      - the female
+If you are not used to command line programs, there are also graphical interface applications for Git, like [Git Cola](https://git-cola.github.io/), [TortoiseGit](https://tortoisegit.org/) etc. They can basically do the same thing but graphically. But we'll focus on the command line here. If you want to use them, consult their documentation to get your way around them.
 
-Phrases:
-  - Phrase: La femme dit bonjour
-    Alternative versions:
-      - la femme dit salut
-    Translation: The woman says hello
-    Alternative translations:
-      - The woman says hi
+To clone the repository you forked into earlier:
 
-  - Phrase: L'homme dit bonjour
-    Alternative versions:
-      - L'homme dit salut
-    Translation: The man says hello
-    Alternative translations:
-      - The man says hi
-
-Mini-dictionary:
-  French:
-    - dit: says
-    - bonjour:
-        - hello
-        - hi
-    - L'homme: the man
-
-  English:
-    - says: dit
-    - hello:
-        - bonjour
-        - salut
+```sh
+git clone <URL you copied>
+cd LibreLingo
 ```
 
-While the meaning of this file should be relatively straight-forward, here's
-a couple things to keep in mind:
+The first command will download the forked repository on your computer so that you can make edits. Second one will go inside the repository directory for future `git` commands to work.
 
-- `Skill:`
-  - `Id:` never change this value. This value identifies the skill uniquely, thus changing it will effectively create a new skill and delete the old one.
-  - `Thumbnails:` these thumbnails can be used to illustrate the skill on the course summary page
+In order to add your name and email to the changes you do later, git would need to know them before you apply any changes to the code. You can add these by running:
 
-### By example
-
-For example, this is how you'd want to add a new alternative version to the
-phrase "La femme dit bonjour":
-
-```diff
-Phrases:
-  - Phrase: La femme dit bonjour
-    Alternative versions:
-      - La femme dit salut
-+     - La madame dit salut
-    Translation: The woman says hello
-    Alternative translations:
-      - The woman says hi
+```sh
+git config --global user.name "John Doe"
+git config --global user.email "john@example.com"
 ```
 
-Keep in mind that when you add a new phrase, or a new version or translation
-to a phrase, it's not automatically updating to the mini-dictionary. So you'd
-want to add any new words there:
+_**NOTE:** Replace the name and email above to match yours. Setting `--global` sets these values globally for any repo on the machine. You can run it without the `--global` parameter to set it for this repo only._
 
-```diff
-Mini-dictionary:
-  French:
-    - dit: says
-+   - madame: lady
-    - bonjour:
-      - hello
-      - hi
-    - L'homme: the man
+Now create a new branch for your changes:
+
+```sh
+git checkout -b my-awesome-branch main
 ```
 
-### Creating new skills
+This is creating a new branch named `my-awesome-branch` from `main` branch and switches to the new branch. The branch name doesn't matter that much. You just need to be able to recognize it yourself from a list of other branches.
 
-Creating new skills is a matter of creating their corresponding YAML file.
-That being said, there are a couple things to keep in mind:
+You can just name it as your language name if you want, but without spaces (e.g. `korean`, `ancient-greek`). You can check which branch you are on by running `git status` and checking the "On branch" line.
 
-- Skills should have a unique `Id`. Such identifiers can be generated using
-  [this website](https://www.uuidgenerator.net/version4).
-- Before skills will actually show up in the web app, they need to be added to
-  a module. See the section below.
+You are now ready to make changes.
 
-## Editing modules
+<a id="pushing-and-pr"></a>
+### Pushing code and creating Pull Request
 
-Modules are simply groups of skills. Their YAML files are quite straightforward.
+These instructions are written to be used after making the changes. So you can read the rest of the page and continue from here if you want.
 
-See `courses/french-from-english/basics/module.yaml` from the example above:
+After you made your changes, add the files and commit your changes:
 
-```yaml
-Module:
-  Name: Basics
-
-Skills:
-  - hello.yaml
+```sh
+git add courses/
+git commit -m "Add Example language"
 ```
 
-Keep in mind that the order in which the skills appear in this YAML file is
-the order they are meant to appear in the web app as well.
+_**NOTE:** Replace the commit message to describe what it does in your case. Another thing is that make your changes only on one commit because it will be easier to maintain and apply possible changes into later. If you want to add something else to the commit, just use the `--ammend` command below._
 
-### Creating new modules
+This hasn't yet been sent to the repo online. The changes are only on your machine. If you feel like you've missed something, there is a chance you can make the changes and run:
 
-As with creating new skills, creating new modules is also mainly about creating
-their corresponding YAML file. You have to keep in mind that the module will
-only show up in the web app, if it's also listed in the course's
-`course.yaml` file. Here's how you'd add it:
-
-```diff
-Course:
-  Language:
-    Name: French
-    IETF BCP 47: fr
-  For speakers of:
-    Name: English
-    IETF BCP 47: en
-  License:
-    Name: CC BY 3.0
-    Short name: CC BY 3.0
-    Link: https://creativecommons.org/licenses/by/3.0/
-
-Modules:
-  - basics/
-+ - animals/
+```sh
+git add courses/
+git commit --amend --no-edit
 ```
+
+This will add (amend) the new changes to the last commit that you did earlier. To see what changes are included in your last commit, run `git show -1` and use Page up and Page down key to scroll through it all or q to quit.
+
+When you are ready to push the changes:
+
+```sh
+git push origin HEAD
+# or
+git push origin my-awesome-branch
+```
+
+You may be asked to enter your GitHub username and password.
+
+**NOTE:** It's recommended that you [create an access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and use it instead of the password due to security reasons. Due to a change in GitHub's policy, using passwords [will not work](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/) from August 13, 2021 and may not work on certain times during June and July.
+
+Now go to your fork of the project (e.g. `https://github.com/<your github username>/LibreLingo/`). You'll see a message above the file list saying something like "my-awesome-branch had recent pushes less than a minute ago" offering you to "Compare & pull request" with a button. Click the button and explain what your changes are about and post a pull request.
+
+A pull request is a request to apply your changes to the original project. Such a request is not immediately applied, rather goes through a review process.
+
+After you posted the pull request, project maintainers will look into your changes and respond. When they do, you'll get a [notification](https://github.com/notifications) on GitHub.
+
+<a id="following-up-pr"></a>
+### Following up with PR responses
+
+Depending on the Pull Request (PR) you made earlier, you can either get accepted right away (in that case it will be "merged") or you may need to make some changes (you'll get comments). If the project maintainers ask for a change, do this:
+
+- `cd` into the git repository directory, or open a terminal on the directory
+- Make sure you're on the branch in which you made changes earlier. Check with `git status` and if not on proper branch, switch to it with:
+```sh
+git checkout my-awesome-branch
+```
+- **NOTE:** If you don't remember which branch you were in, check the Pull request you made or run `git branch -a` to find out and switch to it.
+- Make the changes requested.
+- Check that the changes are what you were asked to do by running `git diff` (Page up/down to scroll, q to quit).
+- When ready:
+```sh
+git add courses/
+git commit --amend --no-edit
+git push origin HEAD -f
+```
+
+The `-f` switch is to force push so that the existing commit gets updated. **NOTE:** The `git commit --amend` command amends (or updates) the changes into the last commit you made. So it is important that you keep your changes in a branch on a single commit (if you followed the instructions above you should be fine).
+
+<a id="translating"></a>
+## Translating based on an existing course
+
+If you just want to translate an existing course, the simplest way is to copy an existing course. Right now `spanish-from-english` is the most complete. So:
+
+- Go to `courses` directory on the repository you [cloned](#pulling-and-branching) earlier. Make sure you also do the `git checkout` command to create a new branch.
+- Copy `spanish-from-english` and rename the copy as `yourlanguageslug-from-english` (replace `yourlanguageslug` to [your language slug](README.md#things-new-contributors))
+- Edit `yourlanguageslug-from-english/course.yaml` to change keys under `Language` ([details here](course.md#data-breakdown))
+- Now keep editing Spanish parts to translate into your language with a text editor
+- If you need more details, consult [Course](course.md), [Module](module.md) or [Skill](skill.md) documentation
+
+_**NOTE:** When editing existing skill yaml files, do not change the skill IDs since you are just editing existing courses. If you change skill IDs it may create issues. New skill IDs are only needed in case if you create [new skills](skill.md#creating-new)._
+
+When you are done, you can continue to the [pull request section](#pushing-and-pr) to submit the changes.
+
+<a id="editing-existing"></a>
+## Editing existing courses
+
+If you want to make edits to course data, consult [Course](course.md), [Module](module.md) or [Skill](skill.md) documentation for details or [discuss](https://github.com/kantord/LibreLingo/discussions) if you're unsure on how to do something.

--- a/docs/courses/module.md
+++ b/docs/courses/module.md
@@ -1,0 +1,90 @@
+# LibreLingo Documentation on Module
+
+A **Module** resides below the courses within the course structure. It contains [skills](skill.md).
+
+They have less complexity as they're here just to group skills and nothing else. On the frontend they appear as headings to group skills.
+
+To get a better understanding, you can read the [course basics](README.md#basics).
+
+---
+
+**Confused?**
+[Ask people](https://github.com/kantord/LibreLingo/discussions) on GitHub Discussions.
+
+---
+
+**Table of Contents:**
+- [Tree structure](#tree-structure)
+- [`module.yaml`](#yaml)
+  - [Data breakdown](#data-breakdown)
+- [Creating new module](#creating-new)
+
+## Tree structure
+
+A typical tree structure for a module is like this:
+
+```
+courses/spanish-from-english/basics/
+├── module.yaml
+└── skills
+    ├── animals.yaml
+    ├── clothes.yaml
+    ├── food.yaml
+    ├── nature.yaml
+    ├── plurals.yaml
+    ├── professions.yaml
+    ├── verb_plurals.yaml
+    └── verbs.yaml
+```
+
+Here, `animals.yaml`, `clothes.yaml` and `food.yaml` etc. are [skills](skill.md). Directly inside the module directory there is also a file called `module.yaml`. This file contains information about the module (see below).
+
+NOTE: A module directory name should not have spaces, should be written in slug-form and ideally in plain English characters. If your source language is not English, you can try roughly to follow the pronunciation and write it using English characters. The human friendly `Name` in the yaml however, can contain uppercase, spaces and the actual name in source language. The yaml skill files under it should be always inside a directory named `skills`.
+
+NOTE: When a new module is created, it should be listed on the [`course.yaml`](course.md#yaml) under [`Modules` key](course.md#data-breakdown).
+
+<a id="yaml"></a>
+## `module.yaml`
+
+A `module.yaml` file for the Spanish Basics module looks like this:
+
+```yaml
+Module:
+  Name: "Basics"
+
+Skills:
+  - animals.yaml
+  - food.yaml
+  - clothes.yaml
+  - nature.yaml
+  - verbs.yaml
+  - plurals.yaml
+  - verb_plurals.yaml
+  - professions.yaml
+```
+
+### Data breakdown
+
+**`Name`** is the human friendly name of the module. The name should be in the target audience's language or the language you set under `For speakers of` key on your `course.yaml`. For example, if the course is `spanish-from-english`, it should be in English.
+**`Skills`** has a list of yaml files for the skills under the module. NOTE: The order in which the skills appear in this YAML file is the order they will appear in the web app as well.
+
+<a id="creating-new"></a>
+## Creating new module
+
+To create a new module,
+
+- just create a directory under the course with the module name (keep it lowercase and no spaces)
+- Create a `module.yaml` file and put yaml code for the module.
+
+
+For example, `courses/french-from-english/traveling/module.yaml` from the example above:
+
+```yaml
+Module:
+  Name: traveling
+
+Skills:
+  - hello.yaml
+```
+
+Now [create skills](skill.md#creating-new) as you want and list under `Skills` key.

--- a/docs/courses/skill.md
+++ b/docs/courses/skill.md
@@ -1,0 +1,194 @@
+# LibreLingo Documentation on Skill
+
+A **Skill** resides below a Module within the course structure. It's the lowest element in the course hierarchy. It contains data regarding what questions LibreLingo will ask the users.
+
+A skill is usually centered around a specific theme. This could be introducing a new grammar concept or just vocabulary to talk about a certain topic.
+
+To get a better understanding, you can read the [course basics](README.md#basics).
+
+---
+
+**Confused?**
+[Ask people](https://github.com/kantord/LibreLingo/discussions) on GitHub Discussions.
+
+---
+
+**Table of Contents:**
+- [Tree structure](#tree-structure)
+- [`(skill_name).yaml`](#yaml)
+  - [Data breakdown](#data-breakdown)
+- [Creating new skills](#creating-new)
+- [Examples of editing a skill](#example-edit)
+- [Tips for creating good skills](#tips)
+
+## Tree structure
+
+A typical tree structure for skills under a module is as follows:
+
+```
+courses/spanish-from-english/basics/skills/
+├── animals.yaml
+├── clothes.yaml
+├── food.yaml
+├── nature.yaml
+├── plurals.yaml
+├── professions.yaml
+├── verb_plurals.yaml
+└── verbs.yaml
+```
+
+Here, `animals.yaml`, `clothes.yaml` and `food.yaml` etc. are skills. These skill files are kept inside a `skills` folder. The YAML files contain information about the skill (see below).
+
+Skill yaml filenames should not have spaces and should be written in `slug-form`. The human friendly `Name` in the yaml however, can contain uppercase and spaces.
+
+<a id="yaml"></a>
+## `(skill_name).yaml`
+
+As an example, let's look into `courses/french-from-english/basics/skills/hello.yaml` file which looks like this:
+
+```yaml
+Skill:
+  Id: 33bfee7d-de74-4362-bf15-ce165add2dc8
+  Name: Hello
+  Thumbnails:
+    - people1
+    - woman1
+    - man1
+
+New words:
+  - Word: l'homme
+    Translation: the man
+    Images:
+      - man1
+      - man2
+      - man3
+
+  - Word: la femme
+    Synonyms:
+      - la dame
+    Translation: the woman
+    Also accepted:
+      - the female
+
+Phrases:
+  - Phrase: La femme dit bonjour
+    Alternative versions:
+      - la femme dit salut
+    Translation: The woman says hello
+    Alternative translations:
+      - The woman says hi
+
+  - Phrase: L'homme dit bonjour
+    Alternative versions:
+      - L'homme dit salut
+    Translation: The man says hello
+    Alternative translations:
+      - The man says hi
+
+Mini-dictionary:
+  French:
+    - dit: says
+    - bonjour:
+        - hello
+        - hi
+    - L'homme: the man
+
+  English:
+    - says: dit
+    - hello:
+        - bonjour
+        - salut
+```
+
+### Data breakdown
+
+**`Skill`** has information about the skill.
+- `Skill > Name`: The human friendly name of the skill.
+- `Skill > Id`: The ID of the course. **NOTE:** This should be unchanged if you're translating or editing existing course. Only if you're creating a new course, this should have a unique [UUID v4](https://www.uuidgenerator.net/version4) string. Details for which you can find [here](creating-courses.md).
+- `Skill > Thumbnails`: A list of filenames of the thumbnails to be used on the course page to give an idea of the skill. A list of available files can be found on [`apps/web/static/images/`](https://github.com/kantord/LibreLingo/tree/main/apps/web/static/images). The names should be used without extension and without `_tiny` or `_tinier` parts. e.g. `banana2_tinier.jpg` should be written as `banana2`.
+
+**`New words`** has a list of new words that the lesson asks about.
+- `Word`: The word in destination language.
+- `Synonyms`: A list of synonyms of the above word. (optional)
+- `Translation`: Translation of the word in target audience's language.
+- `Also accepted`: A list of synonyms of the `Translation` word above. (optional)
+- `Images`: A list of images for the word that is defined under `Word` or `Translation` above. The image names has to be without extension and without `_tiny` or `_tinier` part.
+
+**`Phrases`** has a list of sentences or phrases that the lession asks about.
+- `Phrase`: The phrase in destination language. e.g. In this case, it's written in Spanish.
+- `Alternative versions`: An alternative version of the above phrase. (optional)
+- `Translation`: Translation of the phrase in target audience's language. e.g. In this case, it's written in English.
+
+**`Mini-dictionary`** has a list of words and meanings. [TODO: Explain where and how it is used]
+- `<destination language>`: A list of words in destination language as key and meaning in target audience's language.
+- `<target audience's language>`: A list of words in target audience's language as key and meaning in destination language.
+
+<a id="creating-new"></a>
+## Creating new skills
+
+Creating new skills is a matter of creating their corresponding YAML file.
+That being said, there are a couple things to keep in mind:
+
+- Skill yaml file should be inside a [module](module.md)'s `skills` directory.
+- Skills should have an unique `Id`. Such identifiers can be generated using
+  [this website](https://www.uuidgenerator.net/version4).
+- Before skills will actually show up in the web app, they need to be added to
+  a [`module.yaml`](module.md#yaml).
+
+<a id="example-edit"></a>
+## Examples of editing a skill
+
+This is how you'd add a new alternative version to the
+phrase "La femme dit bonjour":
+
+```diff
+Phrases:
+  - Phrase: La femme dit bonjour
+    Alternative versions:
+      - La femme dit salut
++     - La madame dit salut
+    Translation: The woman says hello
+    Alternative translations:
+      - The woman says hi
+```
+
+Keep in mind that when you add a new phrase, or a new version or translation
+to a phrase, it's not automatically updating to the mini-dictionary. So you need to
+add any new words there:
+
+```diff
+Mini-dictionary:
+  French:
+    - dit: says
++   - madame: lady
+    - bonjour:
+      - hello
+      - hi
+    - L'homme: the man
+```
+
+Also note, that the new words from each phrase listed under `Phrases` key need to be added for both the source and the target language in the `Mini-dictionary`. For example:
+
+```yaml
+Mini-dictionary:
+  French:
+    - dit: says
+    - bonjour:
+      - hello
+      - hi
+...
+  English:
+    - says: dit
+    - hello:
+      - bonjour
+      - salut
+```
+
+Don't worry about listing the same word more than once in a course. It will not cause any issues if you do so.
+
+<a id="tips"></a>
+## Tips for creating good skills
+
+- When it comes to teaching grammar, your main tool is to teach by example.
+- Use words to teach nouns that can be demonstrated easily with pictures, such as "dog", "car", "tree", "city".
+- Do not try to teach verbs, adjectives, etc. using words. Instead, use them in phrases.


### PR DESCRIPTION
## Description

Makes the courses docs beginner friendly and more reference-able.

**Is this related to any open issue(s)?**

related to issue #1145

**Is there anything you need help with to get this PR merged?**

1. Not sure if a better wording for "target audience's language" should be used. e.g.

	**`Mini-dictionary`**
	- `<destination language>`: A list of words in destination language as key and meaning in target audience's language.

2. The content before was hard wrapped to 80 chars per line. But I didn't do it for my changes. Is it important?
3. There are TODOs in places. e.g. `[TODO: Explain where and how it is used]`
4. I've created separate files for course, module and skill so that they can be referenced from any page on the docs, or even be used as a developer reference or can even be linked on a conversation. Link under the "Table of contents" is recommended to be used. (This is just a note, no help is probably necessary in this case :) )
5. I've added custom anchor names for the headings which might cause long or unpredictable anchor names by GitHub (with `<a id="anchor-name"></a>`). The anchor names are listed on "Table of contents" on each .md where subheadings exist. But I don't know if there's a way to turn off automatic anchors by GitHub.
6. I don't know how to generate json files for webapp, so I couldn't add anything about it.
7. I've noticed there are sound files on `apps/web/static/voice/` but I'm not sure where and how this is used. So completely skipped this.

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [ ] The CI is passing
- [ ] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
