### PR TITLE
fix: correct path for the binary building pipeline

### DIFF
--- a/.semaphore/pipeline_2.yml
+++ b/.semaphore/pipeline_2.yml
@@ -32,6 +32,6 @@ blocks:
             - sem-version go 1.16
             - checkout
             - cache restore website-build-$SEMAPHORE_GIT_PR_SHA
-            - apps/librelingo-server/build.sh __sapper__/export/ binaries/
+            - apps/librelingo-standalone-server/build.sh __sapper__/export/ binaries/
             - artifact push project --force binaries      
 


### PR DESCRIPTION
## Description

This should fix the failing pipeline for the librelingo-standalone-server builds. I forgot to modifiy the path in the pipeline configuration before, sorry.

**Is this related to any open issue(s)?**

fixes #1175

**Is there anything you need help with to get this PR merged?**
