### PR TITLE
chore(docs): Link to chat via matrix.to, instead of riot.im

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://riot.im/app/#/group/+librelingo:matrix.org">💬 Chat</a> •
+  <a href="https://matrix.to/#/+librelingo:matrix.org">💬 Chat</a> •
   <a href="#become-a-contributor">👩‍💻 Contribute!</a> •
   <a href="https://github.com/sponsors/kantord">💵 Sponsor</a>  •
   <a href="https://librelingo.app/docs/">📄 Development docs</a>  •


### PR DESCRIPTION
Little aesthetics for the readme :grin:
Basically, the matrix.to service allows the user to choose which matrix client to open, whereas riot.im just opens the web app for Element (formerly riot).