### PR TITLE
Add missing images for woman in french, german & parsig

### DIFF
--- a/apps/web/src/courses/french-from-english/challenges/hello.json
+++ b/apps/web/src/courses/french-from-english/challenges/hello.json
@@ -270,7 +270,11 @@
     },
     {
       "type": "cards",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": "la femme",
       "meaningInSourceLanguage": "the woman",
       "id": "bd13dcfe4d22",
@@ -279,7 +283,11 @@
     },
     {
       "type": "shortInput",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": [
         "la femme",
         "la dame"

--- a/apps/web/src/courses/german-from-english/challenges/hello.json
+++ b/apps/web/src/courses/german-from-english/challenges/hello.json
@@ -292,7 +292,11 @@
     },
     {
       "type": "cards",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": "Die Frau",
       "meaningInSourceLanguage": "the woman",
       "id": "840d90aea650",
@@ -301,7 +305,11 @@
     },
     {
       "type": "shortInput",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": [
         "Die Frau",
         "Die Dame"

--- a/apps/web/src/courses/parsig-from-english/challenges/basic-1.json
+++ b/apps/web/src/courses/parsig-from-english/challenges/basic-1.json
@@ -181,7 +181,11 @@
     },
     {
       "type": "cards",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": "zan",
       "meaningInSourceLanguage": "woman",
       "id": "64cf455940f5",
@@ -190,7 +194,11 @@
     },
     {
       "type": "shortInput",
-      "pictures": null,
+      "pictures": [
+        "woman1.jpg",
+        "woman2.jpg",
+        "woman3.jpg"
+      ],
       "formInTargetLanguage": [
         "zan"
       ],

--- a/courses/french-from-english/basics/skills/hello.yaml
+++ b/courses/french-from-english/basics/skills/hello.yaml
@@ -20,6 +20,10 @@ New words:
     Translation: the woman
     Also accepted:
       - the female
+    Images:
+      - woman1
+      - woman2
+      - woman3
 
 Phrases:
   - Phrase: La femme dit bonjour

--- a/courses/german-from-english/basics/skills/hello.yaml
+++ b/courses/german-from-english/basics/skills/hello.yaml
@@ -20,6 +20,10 @@ New words:
     Translation: the woman
     Also accepted:
       - the female
+    Images:
+      - woman1
+      - woman2
+      - woman3
 
 Phrases:
   - Phrase: Die Frau sagt hallo

--- a/courses/parsig-from-english/basics/skills/hello.yaml
+++ b/courses/parsig-from-english/basics/skills/hello.yaml
@@ -18,6 +18,10 @@ New words:
     Translation: woman
     Also accepted:
       - wife
+    Images:
+      - woman1
+      - woman2
+      - woman3
 
 Phrases:
   - Phrase: zan nipišt


### PR DESCRIPTION
## Description
I believe this line https://github.com/kantord/LibreLingo/blob/d1d2a57082534833c49ad378cd8e831cfce9cafa/apps/web/src/components/ChallengeScreen.svelte#L89
results in an error for french, parsig & german languages because "woman" has no image associated with it in. So I added a pictures array in the json and references to the images in the yaml files

**Is this related to any open issue(s)?**
fixes #1315 

**Screenshots**
Before update (tested with german, parsig & french): 
![image](https://user-images.githubusercontent.com/55817894/125177979-5e71af80-e1ae-11eb-8bad-ca24ebe10e0a.png)
After update (tested with german, parsig & french):
![image](https://user-images.githubusercontent.com/55817894/125178280-5b2bf300-e1b1-11eb-9c23-ec9450e066d1.png)

(only one image seems to load for cards but it's no longer responding with an error. I think this is because there aren't enough cards in the challenge)

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [ ] The CI is passing
- [x] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
