### PR TITLE
fix: do not display multiple of the same option in options challenges

### DIFF
--- a/apps/web/src/courses/test/challenges/cards-test.json
+++ b/apps/web/src/courses/test/challenges/cards-test.json
@@ -51,11 +51,11 @@
         "pasta1.jpg",
         "pasta1.jpg"
       ],
-      "formInTargetLanguage": "pasta",
+      "formInTargetLanguage": "pasta1",
       "meaningInSourceLanguage": "pasta__1",
-      "id": "573e78d0b0ca",
+      "id": "19a98007d4a9",
       "priority": 0,
-      "group": "41b42c828c18"
+      "group": "df20ea8d8531"
     },
     {
       "type": "shortInput",
@@ -65,26 +65,26 @@
         "pasta1.jpg"
       ],
       "formInTargetLanguage": [
-        "pasta"
+        "pasta1"
       ],
       "phrase": [
         {
           "word": "pasta__1",
-          "definition": "pasta"
+          "definition": "pasta1"
         }
       ],
-      "id": "feebd25bb5ff",
+      "id": "43aec690db9b",
       "priority": 1,
-      "group": "41b42c828c18"
+      "group": "df20ea8d8531"
     },
     {
       "type": "listeningExercise",
-      "answer": "pasta",
+      "answer": "pasta1",
       "meaning": "pasta__1",
-      "audio": "75a1fd14a3586626fbdabfc11811f85bf56e3affaa522e555a32fc5cfaed28df",
-      "id": "537cae331583",
+      "audio": "f6226fcd945c9b49d1fd07dba4176c6833d7f4fc733d8225f20c30a311f8d0d7",
+      "id": "f522b7b5dfbc",
       "priority": 1,
-      "group": "41b42c828c18"
+      "group": "df20ea8d8531"
     },
     {
       "type": "cards",
@@ -93,11 +93,11 @@
         "pasta1.jpg",
         "pasta1.jpg"
       ],
-      "formInTargetLanguage": "pasta",
+      "formInTargetLanguage": "pasta2",
       "meaningInSourceLanguage": "pasta__2",
-      "id": "ff1c56e07213",
+      "id": "d546b3adfabb",
       "priority": 0,
-      "group": "004e1f45b69e"
+      "group": "fae91e41ded8"
     },
     {
       "type": "shortInput",
@@ -107,26 +107,26 @@
         "pasta1.jpg"
       ],
       "formInTargetLanguage": [
-        "pasta"
+        "pasta2"
       ],
       "phrase": [
         {
           "word": "pasta__2",
-          "definition": "pasta"
+          "definition": "pasta2"
         }
       ],
-      "id": "320e7e510f9d",
+      "id": "df5fd718c091",
       "priority": 1,
-      "group": "004e1f45b69e"
+      "group": "fae91e41ded8"
     },
     {
       "type": "listeningExercise",
-      "answer": "pasta",
+      "answer": "pasta2",
       "meaning": "pasta__2",
-      "audio": "75a1fd14a3586626fbdabfc11811f85bf56e3affaa522e555a32fc5cfaed28df",
-      "id": "f7a3bc240e59",
+      "audio": "7da0f2a6021270f0b05b3db62a6c9c3283928429629acda0d31f9051c4a4648d",
+      "id": "efe997c7a8aa",
       "priority": 1,
-      "group": "004e1f45b69e"
+      "group": "fae91e41ded8"
     },
     {
       "type": "cards",
@@ -135,11 +135,11 @@
         "pasta1.jpg",
         "pasta1.jpg"
       ],
-      "formInTargetLanguage": "pasta",
+      "formInTargetLanguage": "pasta3",
       "meaningInSourceLanguage": "pasta__3",
-      "id": "cbf577f40e8f",
+      "id": "62eb6663223e",
       "priority": 0,
-      "group": "a860f5d30301"
+      "group": "ebba45a45a9a"
     },
     {
       "type": "shortInput",
@@ -149,26 +149,26 @@
         "pasta1.jpg"
       ],
       "formInTargetLanguage": [
-        "pasta"
+        "pasta3"
       ],
       "phrase": [
         {
           "word": "pasta__3",
-          "definition": "pasta"
+          "definition": "pasta3"
         }
       ],
-      "id": "57428bc488cb",
+      "id": "cd7720c7fd96",
       "priority": 1,
-      "group": "a860f5d30301"
+      "group": "ebba45a45a9a"
     },
     {
       "type": "listeningExercise",
-      "answer": "pasta",
+      "answer": "pasta3",
       "meaning": "pasta__3",
-      "audio": "75a1fd14a3586626fbdabfc11811f85bf56e3affaa522e555a32fc5cfaed28df",
-      "id": "04ec27ea5364",
+      "audio": "1bbdd4d80ba54fac3483b4e61a121112f7ef40861267234a9dfe239f9c2eb234",
+      "id": "12783c8f5ba6",
       "priority": 1,
-      "group": "a860f5d30301"
+      "group": "ebba45a45a9a"
     }
   ]
 }

--- a/apps/web/src/courses/test/courseData.json
+++ b/apps/web/src/courses/test/courseData.json
@@ -138,9 +138,9 @@
         {
           "summary": [
             "pasta",
-            "pasta",
-            "pasta",
-            "pasta"
+            "pasta1",
+            "pasta2",
+            "pasta3"
           ],
           "practiceHref": "cards-test",
           "id": "a8dbe791bff7",

--- a/apps/web/src/logic.js
+++ b/apps/web/src/logic.js
@@ -1,4 +1,5 @@
 import shuffle from "lodash.shuffle"
+import uniqBy from "lodash.uniqby"
 
 export const prepareChallenge = ({
     currentChallenge,
@@ -14,15 +15,17 @@ export const prepareChallenge = ({
 
     const incorrectOptions = alternativeChallenges
         .filter(({ type }) => type === typeToSelect)
+        .filter(
+          ({ formInTargetLanguage }) => formInTargetLanguage !== correctOption.formInTargetLanguage
+        )
         .map((challenge) => ({
             ...challenge,
             correct: false,
         }))
 
-    const incorrectOptionsSample = shuffle(incorrectOptions).slice(
-        0,
-        numberOfCards - 1
-    )
+    const incorrectOptionsSample = shuffle(uniqBy(incorrectOptions, 'formInTargetLanguage'))
+      .slice(0, numberOfCards - 1)
+
     const incorrectOptionsWithFake =
     incorrectOptions.length >= 2
         ? [

--- a/apps/web/src/logic.js
+++ b/apps/web/src/logic.js
@@ -16,15 +16,15 @@ export const prepareChallenge = ({
     const incorrectOptions = alternativeChallenges
         .filter(({ type }) => type === typeToSelect)
         .filter(
-          ({ formInTargetLanguage }) => formInTargetLanguage !== correctOption.formInTargetLanguage
+            ({ formInTargetLanguage }) => formInTargetLanguage !== correctOption.formInTargetLanguage
         )
         .map((challenge) => ({
             ...challenge,
             correct: false,
         }))
 
-    const incorrectOptionsSample = shuffle(uniqBy(incorrectOptions, 'formInTargetLanguage'))
-      .slice(0, numberOfCards - 1)
+    const incorrectOptionsSample = shuffle(uniqBy(incorrectOptions, "formInTargetLanguage"))
+        .slice(0, numberOfCards - 1)
 
     const incorrectOptionsWithFake =
     incorrectOptions.length >= 2

--- a/courses/test/basics/skills/_cards_test.yaml
+++ b/courses/test/basics/skills/_cards_test.yaml
@@ -10,21 +10,21 @@ New words:
       - pasta1
       - pasta1
 
-  - Word: pasta
+  - Word: pasta1
     Translation: pasta__1
     Images:
       - pasta1
       - pasta1
       - pasta1
 
-  - Word: pasta
+  - Word: pasta2
     Translation: pasta__2
     Images:
       - pasta1
       - pasta1
       - pasta1
 
-  - Word: pasta
+  - Word: pasta3
     Translation: pasta__3
     Images:
       - pasta1


### PR DESCRIPTION
Prevents the user from seeing multiple copies of the same option in an options challenge.