### PR TITLE
fix: Accept solutions to chips challenges regardless of case

### DIFF
--- a/apps/web/cypress/integration/chips.feature
+++ b/apps/web/cypress/integration/chips.feature
@@ -53,3 +53,15 @@ Feature: Chips challenge
     And I see a "Continue" button
     Given I click "Continue"
     Then I see a panel with only a skip and a finish early button
+
+    Scenario: Submitting an alternative correct solution with uncapitalized chips
+      Given I open "/course/test/skill/chips-test-0?testChallenge=59cd9b603be9"
+      And I click "como"
+      And I click "estás"
+      And I click "hoy"
+      Given I click "Submit"
+      Then I see the challenge panel with no skip button
+      And I read "Correct solution"
+      And I see a "Continue" button
+      Given I click "Continue"
+      Then I see a panel with only a skip and a finish early button

--- a/apps/web/src/components/ChipsChallenge/index.svelte
+++ b/apps/web/src/components/ChipsChallenge/index.svelte
@@ -27,9 +27,9 @@
       if (!$answer) return
       if (submitted) return
       correct = false
-      const answerForm = $answer.join(" ")
+      const answerForm = $answer.join(" ").toLowerCase()
       challenge.solutions.map((solution: string[]) => {
-          correct = correct || answerForm === solution.join(" ")
+          correct = correct || answerForm === solution.join(" ").toLowerCase()
       })
       registerResult(correct)
       submitted = true

--- a/apps/web/src/courses/test/challenges/chips-test-0.json
+++ b/apps/web/src/courses/test/challenges/chips-test-0.json
@@ -156,6 +156,11 @@
           "como",
           "estás",
           "hoy"
+        ],
+        [
+          "Como",
+          "estás",
+          "hoy"
         ]
       ],
       "formattedSolution": "Tu como estás hoy?",

--- a/courses/test/basics/skills/chips-test-0.yaml
+++ b/courses/test/basics/skills/chips-test-0.yaml
@@ -10,6 +10,8 @@ Phrases:
 
   - Translation: How are you today?
     Phrase: Tu como estás hoy?
+    Alternative versions:
+      - Como estás hoy?
 
 New words: []
 


### PR DESCRIPTION
As mentioned [here](https://github.com/kantord/LibreLingo/issues/1445#issuecomment-890482465), requiring correct capitalization for chips challenge solutions is not intended. This change implements that, so that "como pan" is correct if there is an alternative solution "Como pan".
