### PR TITLE
fix: About page results in "Error: 500"

### DIFF
--- a/apps/web/src/routes/about.svelte
+++ b/apps/web/src/routes/about.svelte
@@ -11,7 +11,7 @@
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
           await getMarkDownData(await import("../../../../README.md"))
-      ).contents.split("<h2>Tech stack</h2>")[0],
+      ).split("<h2>Tech stack</h2>")[0],
       }
   }
 </script>


### PR DESCRIPTION
## Description
This removes accessing the 'content' string from about as the content string is what now gets returned from 'MarkDownPage'

**Is this related to any open issue(s)?**

fixes #1484

**Is there anything you need help with to get this PR merged?**
No

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [x] The CI is passing
- [x] I tested my implementation manually