### PR TITLE
fix: Enable audio settings test course

### DIFF
--- a/courses/test/course.yaml
+++ b/courses/test/course.yaml
@@ -34,3 +34,7 @@ Course:
 
 Modules:
   - basics
+
+Settings:
+    Audio:
+      Enabled: True


### PR DESCRIPTION
## Description
Enables audio setting on test course. This is so when we run `yarn exportAllCourses` it doesn't result in a diff. 
Prerequisite for https://github.com/kantord/LibreLingo/pull/1610. 

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [x] The CI is passing
- [x] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
