### PR TITLE
fix: Add Development Doc translation and English only notice

### DIFF
--- a/apps/web/src/routes/index.svelte
+++ b/apps/web/src/routes/index.svelte
@@ -85,7 +85,7 @@
               </Hidden>
 
               <Button style="primary" href="https://librelingo.app/docs/">
-                <Translate key="index.development_docs">
+                <Translate key="index.development_docs_english_only">
                   Development documentation
                 </Translate>
               </Button>

--- a/apps/web/src/translation/en.json
+++ b/apps/web/src/translation/en.json
@@ -8,5 +8,6 @@
     "about.meta.description": "LibreLingo is an open source, community-driven language-learning platform that gives its users and contributors a way to influence its future.",
     "development.meta.description": "Read about the recent major new features in LibreLingo, an experiment to create a community driven language-learning platform.",
     "sign-up.meta.description": "Sign up to LibreLingo and learn a language for free.",
-    "index.development_docs": "Development documentation (English only)"
+    "index.development_docs": "Development documentation",
+    "index.development_docs_english_only": "Development documentation (English only)"
 }

--- a/apps/web/src/translation/eo.json
+++ b/apps/web/src/translation/eo.json
@@ -3,5 +3,5 @@
     "index.start_spanish_course": "Eklerni la hispanan",
     "index.about_librelingo": "Pri LibreLingo",
     "meta.title": "LibreLingo - libere lernu lingvon",
-    "index.development_docs": "Disvolva Dokumentaro (nur en la angla)"
+    "index.development_docs_english_only": "Disvolva Dokumentaro (nur en la angla)"
 }

--- a/apps/web/src/translation/it.json
+++ b/apps/web/src/translation/it.json
@@ -3,5 +3,5 @@
     "index.start_spanish_course": "Incomincia a imparare lo spagnolo",
     "index.about_librelingo": "Informazioni su LibreLingo",
     "meta.title": "LibreLingo - impara liberamente una lingua",
-    "index.development_docs": "Documentazione di sviluppo (solo in inglese)"
+    "index.development_docs_english_only": "Documentazione di sviluppo (solo in inglese)"
 }


### PR DESCRIPTION
## Description

Adds translation for Development Documentation button for existing translations and adds a notice that these docs are in English only.

**Is this related to any open issue(s)?**

fixes #1563 

**Is there anything you need help with to get this PR merged?**

Check if the translations are OK

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [x] The CI is passing
- [x] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
