### PR TITLE
gitignore every course except "test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,13 +39,7 @@ report.*.*.json
 apps/docs/build/
 __sapper__
 .yarn
-/apps/web/src/courses/bangla-from-english
-/apps/web/src/courses/bangla-from-english
-/apps/web/src/courses/french-from-english
-/apps/web/src/courses/german-from-english
-/apps/web/src/courses/parsig-from-english
-/apps/web/src/courses/spanish-from-english
-/courses/spanish-from-english
-/courses/german-from-english
+/apps/web/src/courses/*-*
+/courses/*-*
 profile.dat
 /apps/librelingo_json_export/profile.png


### PR DESCRIPTION
When someone develop a course it will show up in these two directories
and we would like to ignore them. We cannot gitignore the whole
directories /apps/web/src/courses/ and /courses/ because we have the
"test" directory in both.
We can assume that every course will have a dash in its name so
we ignore those.

# edit this template according to your needs, delete anything that's not relevant

## Description

_Short description of the changes you made. Not necessary if it's clear based on the issue you're resolving_

**Is this related to any open issue(s)?**

fixes #{issue id here}

**Is there anything you need help with to get this PR merged?**

_..._

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [ ] The CI is passing
- [ ] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
