### PR TITLE
Remove consider using from import

### DIFF
--- a/apps/librelingo_audios/tests/test_update_audios.py
+++ b/apps/librelingo_audios/tests/test_update_audios.py
@@ -2,7 +2,7 @@ from librelingo_fakes import fakes
 from librelingo_types import Settings, AudioSettings, TextToSpeechSettings
 
 from librelingo_audios.update_audios import update_audios_for_course
-import librelingo_audios.cli as cli
+from librelingo_audios import cli
 
 course = fakes.customize(
     fakes.course1,

--- a/pylintrc
+++ b/pylintrc
@@ -123,7 +123,6 @@ disable=raw-checker-failed,
         redefined-argument-from-local,  # TODO: enable
         too-many-arguments,  # TODO: enable
         consider-using-set-comprehension,  # TODO: enable
-        consider-using-from-import,  # TODO: enable
         subprocess-run-check,  # TODO: enable
         use-symbolic-message-instead
 


### PR DESCRIPTION
## Description

Fixes issue #1900. Removed "consider-using-from-import" from pylintrc and corrected the code accordingly.
**Is this related to any open issue(s)?**

fixes #1900 

_..._

## Checklist

Don't worry if you haven't done everything on this checklist. Simply create your PR, and make sure everything is done later,
or ask for help if you don't know how to do it.

- [ ] The CI is passing
- [ ] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
