### PR TITLE
refactor(tests): add test_challenges_get_challenges_data.py

### DIFF
--- a/apps/librelingo_json_export/tests/test_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges.py
@@ -2,7 +2,6 @@ import collections
 
 from unittest.mock import patch
 from unittest import TestCase
-from librelingo_json_export.challenges import _get_challenges_data
 from librelingo_json_export.challenges import _get_word_challenges
 from librelingo_json_export.challenges import _get_phrase_challenges
 from librelingo_json_export.challenge_types import get_cards_challenge
@@ -13,44 +12,6 @@ from librelingo_json_export.challenge_types import get_options_challenge
 from librelingo_json_export.challenge_types import get_chips_from_phrase
 from librelingo_types import Settings, AudioSettings
 from librelingo_fakes import fakes
-
-
-class TestGetChallengesData(TestCase):
-    def test_empty_skill(self):
-        self.assertEqual(_get_challenges_data(fakes.emptySkill, fakes.course1), [])
-
-    @patch("librelingo_json_export.challenges._get_phrase_challenges")
-    def test_generates_phrase_challenges_correctly(self, mock):
-        # pylint: disable=no-self-use
-        _get_challenges_data(fakes.skillWithPhrase, fakes.course1)
-        mock.assert_called_with(fakes.phrase2, fakes.course1)
-
-    @patch("librelingo_json_export.challenges._get_phrase_challenges")
-    def test_includes_every_phrase(self, mock):
-        _get_challenges_data(fakes.skillWith3Phrases, fakes.course1)
-        self.assertEqual(mock.call_count, 3)
-
-    @patch("librelingo_json_export.challenges._get_word_challenges")
-    def test_generates_word_challenges_correctly(self, mock):
-        # pylint: disable=no-self-use
-        _get_challenges_data(fakes.skillWithWord, fakes.course1)
-        mock.assert_called_with(fakes.word1, fakes.course1)
-
-    @patch("librelingo_json_export.challenges._get_word_challenges")
-    def test_includes_every_word(self, mock):
-        _get_challenges_data(fakes.skillWith3Words, fakes.course1)
-        self.assertEqual(mock.call_count, 3)
-
-    @patch("librelingo_json_export.challenges._get_word_challenges")
-    @patch("librelingo_json_export.challenges._get_phrase_challenges")
-    def test_returns_correct_challenges(self, mock1, mock2):
-
-        mock1.return_value = [fakes.challenge1, fakes.challenge2]
-        mock2.return_value = [fakes.challenge3, fakes.challenge4]
-        self.assertEqual(
-            _get_challenges_data(fakes.skillWithPhraseAndWord, fakes.course1),
-            [fakes.challenge1, fakes.challenge2, fakes.challenge3, fakes.challenge4],
-        )
 
 
 class TestGetWordChallenges(TestCase):

--- a/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
@@ -1,0 +1,51 @@
+import pytest
+
+from librelingo_json_export.challenges import _get_challenges_data
+from librelingo_fakes import fakes
+
+
+@pytest.fixture
+def mocks(mocker):
+    return {
+        "get_phrase_challenges": mocker.patch(
+            "librelingo_json_export.challenges._get_phrase_challenges"
+        ),
+        "get_word_challenges": mocker.patch(
+            "librelingo_json_export.challenges._get_word_challenges"
+        ),
+    }
+
+
+def test_empty_skill():
+    assert _get_challenges_data(fakes.emptySkill, fakes.course1) == []
+
+
+def test_generates_phrase_challenges_correctly(mocks):
+    _get_challenges_data(fakes.skillWithPhrase, fakes.course1)
+    mocks["get_phrase_challenges"].assert_called_with(fakes.phrase2, fakes.course1)
+
+
+def test_includes_every_phrase(mocks):
+    _get_challenges_data(fakes.skillWith3Phrases, fakes.course1)
+    assert mocks["get_phrase_challenges"].call_count == 3
+
+
+def test_generates_word_challenges_correctly(mocks):
+    _get_challenges_data(fakes.skillWithWord, fakes.course1)
+    mocks["get_word_challenges"].assert_called_with(fakes.word1, fakes.course1)
+
+
+def test_includes_every_word(mocks):
+    _get_challenges_data(fakes.skillWith3Words, fakes.course1)
+    assert mocks["get_word_challenges"].call_count == 3
+
+
+def test_returns_correct_challenges(mocks):
+    mocks["get_phrase_challenges"].return_value = [fakes.challenge1, fakes.challenge2]
+    mocks["get_word_challenges"].return_value = [fakes.challenge3, fakes.challenge4]
+    assert _get_challenges_data(fakes.skillWithPhraseAndWord, fakes.course1) == [
+        fakes.challenge1,
+        fakes.challenge2,
+        fakes.challenge3,
+        fakes.challenge4,
+    ]


### PR DESCRIPTION
## Description

The first step in rewriting all of the tests using pytest. I have the moved the methods of the the class [`TestGetChallengesData`](https://github.com/kantord/LibreLingo/blob/fdc63c4a4b1fad8ca16672f3db7c7ab8d87114c8/apps/librelingo_json_export/tests/test_challenges.py#L18) to a new file [`test_challenges_get_challenges_data.py`](https://github.com/vil02/LibreLingo/blob/unittest_to_pytest/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py).


_..._

## Checklist

- [ ] The CI is passing
- [ ] I tested my implementation manually
- [ ] I wrote new tests to test my code, or updated existing tests to test my changes
