### PR TITLE
refactor(tests): split mocks

### DIFF
--- a/apps/librelingo_json_export/tests/test_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges.py
@@ -2,7 +2,6 @@ import collections
 
 from unittest.mock import patch
 from unittest import TestCase
-from librelingo_json_export.challenges import _get_word_challenges
 from librelingo_json_export.challenges import _get_phrase_challenges
 from librelingo_json_export.challenge_types import get_cards_challenge
 from librelingo_json_export.challenge_types import get_short_input_challenge
@@ -12,32 +11,6 @@ from librelingo_json_export.challenge_types import get_options_challenge
 from librelingo_json_export.challenge_types import get_chips_from_phrase
 from librelingo_types import Settings, AudioSettings
 from librelingo_fakes import fakes
-
-
-class TestGetWordChallenges(TestCase):
-    @patch("librelingo_json_export.challenges.get_cards_challenge")
-    def test_includes_cards_challenges(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_word_challenges(fakes.word1, fakes.course1)[0], fake_value
-        )
-
-    @patch("librelingo_json_export.challenges.get_short_input_challenge")
-    def test_includes_short_input_challenges(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_word_challenges(fakes.word1, fakes.course1)[1], fake_value
-        )
-
-    @patch("librelingo_json_export.challenges.get_listening_challenge")
-    def test_includes_listening_challenge(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_word_challenges(fakes.word1, fakes.course1)[2], fake_value
-        )
 
 
 class TestGetPhraseChallenges(TestCase):

--- a/apps/librelingo_json_export/tests/test_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges.py
@@ -2,7 +2,6 @@ import collections
 
 from unittest.mock import patch
 from unittest import TestCase
-from librelingo_json_export.challenges import _get_phrase_challenges
 from librelingo_json_export.challenge_types import get_cards_challenge
 from librelingo_json_export.challenge_types import get_short_input_challenge
 from librelingo_json_export.challenge_types import get_listening_challenge
@@ -11,65 +10,6 @@ from librelingo_json_export.challenge_types import get_options_challenge
 from librelingo_json_export.challenge_types import get_chips_from_phrase
 from librelingo_types import Settings, AudioSettings
 from librelingo_fakes import fakes
-
-
-class TestGetPhraseChallenges(TestCase):
-    @patch("librelingo_json_export.challenges.get_options_challenge")
-    def test_includes_options_challenges(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_phrase_challenges(fakes.phrase1, fakes.course1)[0], fake_value
-        )
-
-    @patch("librelingo_json_export.challenges.get_listening_challenge")
-    def test_includes_listening_challenge(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_phrase_challenges(fakes.phrase1, fakes.course1)[1], fake_value
-        )
-
-    @patch("librelingo_json_export.challenges.get_chips_challenge")
-    def test_includes_chips_challenge(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_phrase_challenges(fakes.long_phrase, fakes.course1)[2], fake_value
-        )
-
-    @patch("librelingo_json_export.challenges.get_reverse_chips_challenge")
-    def test_includes_reverse_chips_challenge(self, mock):
-        fake_value = fakes.fake_value()
-        mock.return_value = [fake_value]
-        self.assertEqual(
-            _get_phrase_challenges(fakes.long_phrase, fakes.course1)[3], fake_value
-        )
-
-    def test_returns_correct_number_of_challenged(self):
-        self.assertEqual(
-            len(_get_phrase_challenges(fakes.long_phrase, fakes.course1)), 4
-        )
-
-    def test_doesnt_include_chips_if_sentence_is_short(self):
-        self.assertEqual(
-            len(
-                list(
-                    filter(
-                        lambda x: x["type"] == "chips",
-                        _get_phrase_challenges(
-                            fakes.customize(
-                                fakes.phrase1,
-                                in_target_language=["foo"],
-                                in_source_language=["bar"],
-                            ),
-                            fakes.course1,
-                        ),
-                    )
-                )
-            ),
-            0,
-        )
 
 
 class TestGetCardsChallenge(TestCase):

--- a/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
@@ -5,44 +5,44 @@ from librelingo_fakes import fakes
 
 
 @pytest.fixture
-def mocks(mocker):
-    return {
-        "get_phrase_challenges": mocker.patch(
-            "librelingo_json_export.challenges._get_phrase_challenges"
-        ),
-        "get_word_challenges": mocker.patch(
-            "librelingo_json_export.challenges._get_word_challenges"
-        ),
-    }
+def mock_get_phrase_challenges(mocker):
+    return mocker.patch("librelingo_json_export.challenges._get_phrase_challenges")
+
+
+@pytest.fixture
+def mock_get_word_challenges(mocker):
+    return mocker.patch("librelingo_json_export.challenges._get_word_challenges")
 
 
 def test_empty_skill():
     assert _get_challenges_data(fakes.emptySkill, fakes.course1) == []
 
 
-def test_generates_phrase_challenges_correctly(mocks):
+def test_generates_phrase_challenges_correctly(mock_get_phrase_challenges):
     _get_challenges_data(fakes.skillWithPhrase, fakes.course1)
-    mocks["get_phrase_challenges"].assert_called_with(fakes.phrase2, fakes.course1)
+    mock_get_phrase_challenges.assert_called_with(fakes.phrase2, fakes.course1)
 
 
-def test_includes_every_phrase(mocks):
+def test_includes_every_phrase(mock_get_phrase_challenges):
     _get_challenges_data(fakes.skillWith3Phrases, fakes.course1)
-    assert mocks["get_phrase_challenges"].call_count == 3
+    assert mock_get_phrase_challenges.call_count == 3
 
 
-def test_generates_word_challenges_correctly(mocks):
+def test_generates_word_challenges_correctly(mock_get_word_challenge):
     _get_challenges_data(fakes.skillWithWord, fakes.course1)
-    mocks["get_word_challenges"].assert_called_with(fakes.word1, fakes.course1)
+    mock_get_word_challenge.assert_called_with(fakes.word1, fakes.course1)
 
 
-def test_includes_every_word(mocks):
+def test_includes_every_word(mock_get_word_challenges):
     _get_challenges_data(fakes.skillWith3Words, fakes.course1)
-    assert mocks["get_word_challenges"].call_count == 3
+    assert mock_get_word_challenges.call_count == 3
 
 
-def test_returns_correct_challenges(mocks):
-    mocks["get_phrase_challenges"].return_value = [fakes.challenge1, fakes.challenge2]
-    mocks["get_word_challenges"].return_value = [fakes.challenge3, fakes.challenge4]
+def test_returns_correct_challenges(
+    mock_get_phrase_challenges, mock_get_word_challenges
+):
+    mock_get_phrase_challenges.return_value = [fakes.challenge1, fakes.challenge2]
+    mock_get_word_challenges.return_value = [fakes.challenge3, fakes.challenge4]
     assert _get_challenges_data(fakes.skillWithPhraseAndWord, fakes.course1) == [
         fakes.challenge1,
         fakes.challenge2,

--- a/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py
@@ -28,9 +28,9 @@ def test_includes_every_phrase(mock_get_phrase_challenges):
     assert mock_get_phrase_challenges.call_count == 3
 
 
-def test_generates_word_challenges_correctly(mock_get_word_challenge):
+def test_generates_word_challenges_correctly(mock_get_word_challenges):
     _get_challenges_data(fakes.skillWithWord, fakes.course1)
-    mock_get_word_challenge.assert_called_with(fakes.word1, fakes.course1)
+    mock_get_word_challenges.assert_called_with(fakes.word1, fakes.course1)
 
 
 def test_includes_every_word(mock_get_word_challenges):

--- a/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
@@ -1,0 +1,73 @@
+import pytest
+
+from librelingo_json_export.challenges import _get_phrase_challenges
+from librelingo_fakes import fakes
+
+
+@pytest.fixture
+def mock_get_options_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_options_challenge")
+
+
+def test_includes_options_challenges(mock_get_options_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_options_challenge.return_value = [fake_value]
+    assert _get_phrase_challenges(fakes.phrase1, fakes.course1)[0] == fake_value
+
+
+@pytest.fixture
+def mock_get_listening_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_listening_challenge")
+
+
+def test_includes_listening_challenge(mock_get_listening_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_listening_challenge.return_value = [fake_value]
+    assert _get_phrase_challenges(fakes.phrase1, fakes.course1)[1] == fake_value
+
+
+@pytest.fixture
+def mock_get_chips_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_chips_challenge")
+
+
+def test_includes_chips_challenge(mock_get_chips_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_chips_challenge.return_value = [fake_value]
+    assert _get_phrase_challenges(fakes.long_phrase, fakes.course1)[2] == fake_value
+
+
+@pytest.fixture
+def mock_get_reverse_chips_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_reverse_chips_challenge")
+
+
+def test_includes_reverse_chips_challenge(mock_get_reverse_chips_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_reverse_chips_challenge.return_value = [fake_value]
+    assert _get_phrase_challenges(fakes.long_phrase, fakes.course1)[3] == fake_value
+
+
+def test_returns_correct_number_of_challenged():
+    assert len(_get_phrase_challenges(fakes.long_phrase, fakes.course1)) == 4
+
+
+def test_doesnt_include_chips_if_sentence_is_short():
+    assert not list(
+        filter(
+            lambda x: x["type"] == "chips",
+            _get_phrase_challenges(
+                fakes.customize(
+                    fakes.phrase1,
+                    in_target_language=["foo"],
+                    in_source_language=["bar"],
+                ),
+                fakes.course1,
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def mock_(mocker):
+    return mocker.patch("")

--- a/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py
@@ -66,8 +66,3 @@ def test_doesnt_include_chips_if_sentence_is_short():
             ),
         )
     )
-
-
-@pytest.fixture
-def mock_(mocker):
-    return mocker.patch("")

--- a/apps/librelingo_json_export/tests/test_challenges_get_word_challenges.py
+++ b/apps/librelingo_json_export/tests/test_challenges_get_word_challenges.py
@@ -1,0 +1,37 @@
+import pytest
+
+from librelingo_json_export.challenges import _get_word_challenges
+from librelingo_fakes import fakes
+
+
+@pytest.fixture
+def mock_get_cards_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_cards_challenge")
+
+
+def test_includes_cards_challenges(mock_get_cards_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_cards_challenge.return_value = [fake_value]
+    assert _get_word_challenges(fakes.word1, fakes.course1)[0] == fake_value
+
+
+@pytest.fixture
+def mock_get_short_input_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_short_input_challenge")
+
+
+def test_includes_short_input_challenges(mock_get_short_input_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_short_input_challenge.return_value = [fake_value]
+    assert _get_word_challenges(fakes.word1, fakes.course1)[1] == fake_value
+
+
+@pytest.fixture
+def mock_get_listening_challenge(mocker):
+    return mocker.patch("librelingo_json_export.challenges.get_listening_challenge")
+
+
+def test_includes_listening_challenge(mock_get_listening_challenge):
+    fake_value = fakes.fake_value()
+    mock_get_listening_challenge.return_value = [fake_value]
+    assert _get_word_challenges(fakes.word1, fakes.course1)[2] == fake_value


### PR DESCRIPTION
## Description

Continuation of rewriting all of the tests using pytest.

- I split [`mocks`](https://github.com/kantord/LibreLingo/blob/3ab2cc73c4ec0c76d27ce3e04ba20dbaa4510c12/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py#L8) into [`mock_get_phrase_challenges`](https://github.com/vil02/LibreLingo/blob/13ac8ffc95e91241e6c85b7128721e738c937764/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py#L8) and [`mock_get_word_challenges`](https://github.com/vil02/LibreLingo/blob/13ac8ffc95e91241e6c85b7128721e738c937764/apps/librelingo_json_export/tests/test_challenges_get_challenges_data.py#L13),
- I moved the methods of the class [`TestGetWordChallenges`](https://github.com/kantord/LibreLingo/blob/3ab2cc73c4ec0c76d27ce3e04ba20dbaa4510c12/apps/librelingo_json_export/tests/test_challenges.py#L17) to a new file [`test_challenges_get_word_challenges.py`](https://github.com/vil02/LibreLingo/blob/unittest_to_pytest/apps/librelingo_json_export/tests/test_challenges_get_word_challenges.py),
- I moved the methods of the class [`TestGetPhraseChallenges`](https://github.com/kantord/LibreLingo/blob/3ab2cc73c4ec0c76d27ce3e04ba20dbaa4510c12/apps/librelingo_json_export/tests/test_challenges.py#L43) to a new file [`test_challenges_get_phrase_challenges.py`](https://github.com/vil02/LibreLingo/blob/ab9244a41d3874ef53edf882649b77bdb108c8a9/apps/librelingo_json_export/tests/test_challenges_get_phrase_challenges.py).
